### PR TITLE
[#22] chore: Main PR 브랜치 가드 구현

### DIFF
--- a/.github/workflows/devths-pr.yml
+++ b/.github/workflows/devths-pr.yml
@@ -8,9 +8,38 @@ env:
   NODE_VERSION: '22.x'
 
 jobs:
+  # 0. main 브랜치 보호: release/hotfix/*만 PR 허용
+  main-branch-guard:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: main PR 브랜치 검증
+        run: |
+          BASE="${{ github.event.pull_request.base.ref }}"
+          HEAD="${{ github.event.pull_request.head.ref }}"
+
+          echo "📌 대상 브랜치: $BASE"
+          echo "📌 소스 브랜치: $HEAD"
+
+          # main이 아닐 땐 통과
+          if [ "$BASE" != "main" ]; then
+            echo "✅ 브랜치 정책 통과 (main 아님)"
+            exit 0
+          fi
+
+          # main일 때 허용 브랜치: release, hotfix/*
+          if [[ "$HEAD" =~ ^release$ || "$HEAD" =~ ^hotfix\/.+$ ]]; then
+            echo "✅ 브랜치 정책 통과 (허용된 소스 브랜치)"
+            exit 0
+          fi
+
+          echo "❌ 정책 위반: main에는 release 또는 hotfix/* 브랜치만 PR 가능"
+          exit 1
+
   # 1. 통합 품질 검사 (Lint + Prettier + TypeCheck)
   lint:
     runs-on: ubuntu-22.04
+    needs: [main-branch-guard]
+    if: needs.main-branch-guard.result == 'success'
     steps:
       - name: 체크아웃
         uses: actions/checkout@v4
@@ -35,6 +64,8 @@ jobs:
   # 2. 정적 분석 (CodeQL)
   static-analysis:
     runs-on: ubuntu-22.04
+    needs: [main-branch-guard]
+    if: needs.main-branch-guard.result == 'success'
     permissions:
       actions: read
       contents: read
@@ -84,8 +115,9 @@ jobs:
   # 3. 빌드 테스트
   build:
     name: build
-    needs: [lint, static-analysis]
+    needs: [main-branch-guard, lint, static-analysis]
     runs-on: ubuntu-22.04
+    if: needs.main-branch-guard.result == 'success'
     steps:
       - name: 체크아웃
         uses: actions/checkout@v4
@@ -119,7 +151,7 @@ jobs:
   # 4. 디스코드 통합 알림
   notify-discord:
     runs-on: ubuntu-22.04
-    needs: [lint, static-analysis, build]
+    needs: [main-branch-guard, lint, static-analysis, build]
     if: always()
     steps:
       - name: 데이터 준비
@@ -127,6 +159,20 @@ jobs:
         env:
           USER_MAP: ${{ secrets.USER_MAP_JSON }}
         run: |
+          # 브랜치 가드 재평가 (main은 release/hotfix/*만 허용)
+          BASE="${{ github.event.pull_request.base.ref }}"
+          HEAD="${{ github.event.pull_request.head.ref }}"
+          if [ "$BASE" == "main" ] && [[ ! "$HEAD" =~ ^release$ && ! "$HEAD" =~ ^hotfix\/.+$ ]]; then
+            GUARD_ALLOWED=false
+            GUARD_REASON="main에는 release 또는 hotfix/* 브랜치만 PR 가능"
+          else
+            GUARD_ALLOWED=true
+            GUARD_REASON="정책 통과"
+          fi
+
+          echo "branch_guard_allowed=$GUARD_ALLOWED" >> $GITHUB_OUTPUT
+          echo "branch_guard_reason=$GUARD_REASON" >> $GITHUB_OUTPUT
+
           # 1. 작성자 멘션화
           LOGIN_ID="${{ github.event.pull_request.user.login }}"
           AUTHOR_RAW=$(echo "$USER_MAP" | jq -r --arg id "$LOGIN_ID" '.[$id] // $id')
@@ -160,21 +206,23 @@ jobs:
         uses: sarisia/actions-status-discord@v1
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          status: ${{ (needs.lint.result == 'success' && needs.static-analysis.result == 'success' && needs.build.result == 'success') && 'success' || 'failure' }}
-          title: "${{ github.event.pull_request.base.ref }} FE PR [${{ (needs.lint.result == 'success' && needs.static-analysis.result == 'success' && needs.build.result == 'success') && '✅성공' || '❌실패' }}]"
+          status: ${{ steps.prep.outputs.branch_guard_allowed == 'true' && needs.lint.result == 'success' && needs.static-analysis.result == 'success' && needs.build.result == 'success' && 'success' || 'failure' }}
+          title: "${{ github.event.pull_request.base.ref }} FE PR [${{ steps.prep.outputs.branch_guard_allowed == 'true' && needs.lint.result == 'success' && needs.static-analysis.result == 'success' && needs.build.result == 'success' && '✅성공' || '❌실패' }}]"
           description: |
             **PR 제목**: ${{ github.event.pull_request.title }}
+            **브랜치 가드**: ${{ steps.prep.outputs.branch_guard_allowed == 'true' && '✅ 통과' || '❌ 차단' }} (이유: ${{ steps.prep.outputs.branch_guard_reason }})
             **작성자**: ${{ steps.prep.outputs.author }}
             **리뷰어**: ${{ steps.prep.outputs.reviewers }}
             **작업 내용**: ${{ steps.prep.outputs.description }}...
             **경로**: `${{ github.event.pull_request.head.ref }}` → `${{ github.event.pull_request.base.ref }}`
 
             **📊 상세 결과**:
-            - Lint/Type: ${{ needs.lint.result == 'success' && ' ✅' || ' ❌' }}
-            - Static Analysis: ${{ needs.static-analysis.result == 'success' && ' ✅' || ' ❌' }}
-            - Build: ${{ needs.build.result == 'success' && ' ✅' || ' ❌' }}
+            - Branch Guard: ${{ steps.prep.outputs.branch_guard_allowed == 'true' && ' ✅' || ' ❌' }}
+            - Lint/Type: ${{ steps.prep.outputs.branch_guard_allowed == 'true' && (needs.lint.result == 'success' && ' ✅' || ' ❌') || ' ⚪️ (브랜치 가드 차단)' }}
+            - Static Analysis: ${{ steps.prep.outputs.branch_guard_allowed == 'true' && (needs.static-analysis.result == 'success' && ' ✅' || ' ❌') || ' ⚪️ (브랜치 가드 차단)' }}
+            - Build: ${{ steps.prep.outputs.branch_guard_allowed == 'true' && (needs.build.result == 'success' && ' ✅' || ' ❌') || ' ⚪️ (브랜치 가드 차단)' }}
 
             **🔗 링크**: [PR 확인하기](${{ github.event.pull_request.html_url }})
-          color: "${{ (needs.lint.result == 'success' && needs.static-analysis.result == 'success' && needs.build.result == 'success') && 65280 || 16711680 }}"
+          color: "${{ steps.prep.outputs.branch_guard_allowed == 'true' && needs.lint.result == 'success' && needs.static-analysis.result == 'success' && needs.build.result == 'success' && 65280 || 16711680 }}"
           username: GitHub FE Bot
           avatar_url: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png


### PR DESCRIPTION
## 📌 작업한 내용
- #22 이슈에 따라 `main` 브랜치에 대한 PR 브랜치 가드(보호 규칙)를 구현했습니다.  
- GitHub 브랜치 보호 설정을 통해 `main` 브랜치에 직접 푸시를 제한하고, PR을 통한 병합만 허용하도록 구성했습니다.  
- PR 템플릿에 브랜치 병합 규칙 관련 체크리스트를 추가하여 팀 규정을 문서화했습니다.  

## 🔍 참고 사항
- 적용 규칙 핵심 포인트:  
  - `main` 브랜치에 `release/`, `hotfix/` 브랜치에서만 PR 병합 가능  
  - `Require a pull request before merging` 활성화  
  - `Restrict pushes that require these rules` 설정으로 규칙이 적용된 브랜치에 대한 푸시 제한  
- 관련 이슈: #22 (chore: 깃허브 PR 관련 브랜치 병합 룰 정의)  
- 커밋 메시지: `chore: Main PR 브랜치 가드 구현 (#22)`  

## 🖼️ 스크린샷
해당 규칙은 GitHub의 Branch protection rules 화면에서 확인 가능한 설정이므로, 별도 UI 스크린샷은 첨부하지 않습니다.  

## 🔗 관련 이슈
- #22  

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료  
- [x] 코드 리뷰 반영 완료  
- [x] 문서화 필요 여부 확인