### PR TITLE
[#28] AI 챗봇을 메인 페이지로 변경 및 네비게이션 UI 개선

### DIFF
--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import clsx from 'clsx';
-import { Bot, Home, User } from 'lucide-react';
+import { Bot, Calendar, User } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
@@ -10,11 +10,12 @@ type Tab = {
   href: string;
   icon: React.ComponentType<{ className?: string }>;
   disabled?: boolean;
+  highlight?: boolean;
 };
 
 const TABS: Tab[] = [
-  { label: '홈', href: '/calendar', icon: Home },
-  { label: 'AI', href: '/llm', icon: Bot },
+  { label: '캘린더', href: '/calendar', icon: Calendar },
+  { label: 'AI', href: '/llm', icon: Bot, highlight: true },
   { label: '프로필', href: '/me', icon: User, disabled: true },
 ];
 
@@ -28,6 +29,28 @@ export default function BottomNav() {
           {TABS.map((tab) => {
             const isActive = pathname.startsWith(tab.href);
             const Icon = tab.icon;
+
+            if (tab.highlight) {
+              return (
+                <Link
+                  key={tab.label}
+                  href={tab.href}
+                  className="flex flex-col items-center justify-center"
+                >
+                  <div className="-mt-6 flex h-14 w-14 items-center justify-center rounded-full bg-neutral-900 shadow-lg">
+                    <Icon className="h-6 w-6 text-white" />
+                  </div>
+                  <span
+                    className={clsx(
+                      'mt-1 text-[11px]',
+                      isActive ? 'font-medium text-neutral-900' : 'text-neutral-500',
+                    )}
+                  >
+                    {tab.label}
+                  </span>
+                </Link>
+              );
+            }
 
             const baseClass = clsx(
               'flex flex-col items-center justify-center gap-1 rounded-md px-2 py-2 text-[11px]',

--- a/src/screens/auth/AuthCallbackClient.tsx
+++ b/src/screens/auth/AuthCallbackClient.tsx
@@ -58,7 +58,7 @@ export default function AuthCallbackClient() {
           }
 
           setAccessToken(accessToken);
-          router.replace('/calendar');
+          router.replace('/llm');
           return;
         }
 


### PR DESCRIPTION
## 📌 작업한 내용

  - AI 챗봇을 메인 페이지로 설정                                                 
    - 로그인 성공 시 /llm 페이지로 리다이렉트 (`AuthCallbackClient.tsx`)           
    - 기존 `/calendar` 리다이렉트에서 변경       
                                  
  - 하단 네비게이션 UI 개선                                                      
    - 탭 순서 변경: 캘린더 → AI (가운데) → 프로필 (`BottomNav.tsx`)                
    - "홈" 탭을 "캘린더"로 변경, Home → Calendar 아이콘 적용                     
    - AI 버튼 강조 스타일 적용 (검정색 원, 위로 튀어나오는 디자인)               
    - 그림자 효과 및 흰색 아이콘으로 시각적 구분       

## 🔍 참고 사항

  - AI 챗봇이 서비스의 핵심 기능으로 메인 진입점이 됨                            
  - 하단 네비게이션에서 AI 버튼이 시각적으로 강조되어 사용자 접근성 향상

## 🖼️ 스크린샷

<img width="1347" height="748" alt="스크린샷 2026-01-27 오후 4 08 28" src="https://github.com/user-attachments/assets/889b3103-a24f-4f12-9eec-01bd63715216" />


## 🔗 관련 이슈

Ref #28 

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
