### PR TITLE
[#44] chore: 운영용 서버 트리거 작동

### DIFF
--- a/.github/workflows/devths-prod.yml
+++ b/.github/workflows/devths-prod.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_PROD_URL }}
           status: ${{ github.event_name }}
-          title: "🔔 운영 배포 승인 요청"
+          title: '🔔 운영 배포 승인 요청'
           description: |
             **배포 요청자**: ${{ github.actor }}
             **요청 시각**: ${{ github.event.created_at }}


### PR DESCRIPTION
## 📌 작업한 내용
운영용 서버 트리거를 수동으로 작동시키는 작업을 완료했습니다. 이슈 #44에서 요청된 chore 작업으로, 운영 환경에서 트리거가 정상 작동하도록 설정하였습니다.

## 🔍 참고 사항
- 관련 이슈 #44를 참조하여 작업 완료
- 코드 변경 사항은 GitHub 커밋 1ef5518757222c3bbc8d785a8af34611d8e0498d에서 확인 가능

## 🖼️ 스크린샷
(현재 UI 변경 사항 없음)

## 🔗 관련 이슈
#44

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인