### PR TITLE
[#28] LLM 분석 진행 상태 연동

### DIFF
--- a/src/components/layout/AppFrame.tsx
+++ b/src/components/layout/AppFrame.tsx
@@ -6,6 +6,7 @@ import { AppFrameContext, type AppFrameOptions } from '@/components/layout/AppFr
 import BottomNav from '@/components/layout/BottomNav';
 import Header from '@/components/layout/Header';
 import { HeaderContext, type HeaderOptions } from '@/components/layout/HeaderContext';
+import LlmAnalysisTaskWatcher from '@/components/llm/analysis/LlmAnalysisTaskWatcher';
 
 import type { CSSProperties, ReactNode } from 'react';
 
@@ -70,6 +71,7 @@ export default function AppFrame({
             } as CSSProperties
           }
         >
+          <LlmAnalysisTaskWatcher />
           <div className="mx-auto min-h-dvh w-full bg-white sm:max-w-[430px]">
             <Header
               title={options.title}

--- a/src/components/llm/analysis/LlmAnalysisTaskWatcher.tsx
+++ b/src/components/llm/analysis/LlmAnalysisTaskWatcher.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef } from 'react';
+
+import { getTaskStatus } from '@/lib/api/llmRooms';
+import { llmKeys } from '@/lib/hooks/llm/queryKeys';
+import { useAnalysisTaskStore } from '@/lib/llm/analysisTaskStore';
+import { toast } from '@/lib/toast/store';
+
+import type { ApiResponse } from '@/types/api';
+import type { TaskResultData } from '@/types/llm';
+
+const POLLING_INTERVAL = 2000;
+
+export default function LlmAnalysisTaskWatcher() {
+  const queryClient = useQueryClient();
+  const { activeTask, updateStatus, clearActiveTask } = useAnalysisTaskStore();
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    const taskId = activeTask?.taskId;
+    if (!taskId) return undefined;
+
+    let isMounted = true;
+
+    const poll = async () => {
+      try {
+        const response = await getTaskStatus(taskId);
+        if (!response.ok || !response.json) {
+          throw new Error('작업 상태 조회에 실패했습니다.');
+        }
+
+        const json = response.json as ApiResponse<TaskResultData>;
+        const data = json.data;
+
+        if (!isMounted) return;
+        updateStatus(data.status);
+
+        if (data.status === 'COMPLETED') {
+          toast('분석이 완료되었습니다. 대화 목록에서 확인하세요.');
+          clearActiveTask();
+          queryClient.invalidateQueries({ queryKey: llmKeys.rooms() });
+        } else if (data.status === 'FAILED') {
+          toast('분석에 실패했습니다. 다시 시도해주세요.');
+          clearActiveTask();
+        }
+      } catch (error) {
+        if (!isMounted) return;
+        toast(error instanceof Error ? error.message : '알 수 없는 오류가 발생했습니다.');
+        clearActiveTask();
+      }
+    };
+
+    poll();
+    intervalRef.current = setInterval(poll, POLLING_INTERVAL);
+
+    return () => {
+      isMounted = false;
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [activeTask?.taskId, clearActiveTask, queryClient, updateStatus]);
+
+  return null;
+}

--- a/src/components/llm/rooms/LlmRoomCreateCard.tsx
+++ b/src/components/llm/rooms/LlmRoomCreateCard.tsx
@@ -5,18 +5,44 @@ import Link from 'next/link';
 
 type Props = {
   href: string;
+  disabled?: boolean;
+  onDisabledClick?: () => void;
 };
 
-export default function LlmRoomCreateCard({ href }: Props) {
+export default function LlmRoomCreateCard({ href, disabled, onDisabledClick }: Props) {
   return (
     <Link
       href={href}
-      className="flex items-center justify-between rounded-2xl border bg-white px-4 py-4 shadow-sm transition hover:border-neutral-300 hover:bg-neutral-50 active:bg-neutral-100"
+      onClick={(event) => {
+        if (!disabled) return;
+        event.preventDefault();
+        event.stopPropagation();
+        onDisabledClick?.();
+      }}
+      aria-disabled={disabled}
+      className={[
+        'flex items-center justify-between rounded-2xl border bg-white px-4 py-4 shadow-sm transition',
+        disabled
+          ? 'cursor-not-allowed border-neutral-200 bg-neutral-50 text-neutral-400 opacity-70'
+          : 'hover:border-neutral-300 hover:bg-neutral-50 active:bg-neutral-100',
+      ].join(' ')}
     >
-      <div className="text-sm font-semibold text-neutral-900">새 대화 시작</div>
+      <div
+        className={[
+          'text-sm font-semibold',
+          disabled ? 'text-neutral-400' : 'text-neutral-900',
+        ].join(' ')}
+      >
+        새 대화 시작
+      </div>
 
-      <div className="inline-flex h-10 w-10 items-center justify-center rounded-full border bg-white">
-        <Plus className="h-5 w-5 text-neutral-900" />
+      <div
+        className={[
+          'inline-flex h-10 w-10 items-center justify-center rounded-full border border-neutral-200 bg-white',
+          disabled ? 'bg-neutral-100' : 'bg-white',
+        ].join(' ')}
+      >
+        <Plus className={disabled ? 'h-5 w-5 text-neutral-400' : 'h-5 w-5 text-neutral-900'} />
       </div>
     </Link>
   );

--- a/src/components/llm/rooms/LlmRoomList.tsx
+++ b/src/components/llm/rooms/LlmRoomList.tsx
@@ -6,17 +6,24 @@ import type { LlmRoom } from '@/components/llm/rooms/types';
 
 type Props = {
   rooms: LlmRoom[];
+  activeAnalysisRoomId?: number | null;
   onEnterRoom: (roomId: string, numericId: number) => void;
   onDeleteRoom: (roomId: string) => void;
 };
 
-export default function LlmRoomList({ rooms, onEnterRoom, onDeleteRoom }: Props) {
+export default function LlmRoomList({
+  rooms,
+  activeAnalysisRoomId,
+  onEnterRoom,
+  onDeleteRoom,
+}: Props) {
   return (
     <div className="flex flex-col gap-4">
       {rooms.map((room) => (
         <LlmRoomListItem
           key={room.id}
           room={room}
+          isAnalyzing={activeAnalysisRoomId === room.numericId}
           onEnter={() => onEnterRoom(room.id, room.numericId)}
           onDelete={onDeleteRoom}
         />

--- a/src/components/llm/rooms/LlmRoomListItem.tsx
+++ b/src/components/llm/rooms/LlmRoomListItem.tsx
@@ -6,11 +6,12 @@ import type { LlmRoom } from '@/components/llm/rooms/types';
 
 type Props = {
   room: LlmRoom;
+  isAnalyzing?: boolean;
   onEnter?: () => void;
   onDelete?: (roomId: string) => void;
 };
 
-export default function LlmRoomListItem({ room, onEnter, onDelete }: Props) {
+export default function LlmRoomListItem({ room, isAnalyzing, onEnter, onDelete }: Props) {
   return (
     <div className="rounded-2xl border bg-white p-4 shadow-sm">
       <div className="flex items-center justify-between gap-3">
@@ -19,7 +20,14 @@ export default function LlmRoomListItem({ room, onEnter, onDelete }: Props) {
           onClick={() => onEnter?.()}
           className="flex min-w-0 flex-1 flex-col text-left"
         >
-          <span className="truncate text-sm font-semibold text-neutral-900">{room.title}</span>
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="truncate text-sm font-semibold text-neutral-900">{room.title}</span>
+            {isAnalyzing ? (
+              <span className="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold text-amber-700">
+                분석 중
+              </span>
+            ) : null}
+          </div>
           <span className="mt-1 text-[11px] text-neutral-500">{room.updatedAt}</span>
         </button>
 

--- a/src/lib/llm/analysisTaskStore.ts
+++ b/src/lib/llm/analysisTaskStore.ts
@@ -1,0 +1,29 @@
+'use client';
+
+import { create } from 'zustand';
+
+import type { LlmModel, TaskStatus } from '@/types/llm';
+
+type AnalysisTask = {
+  taskId: number;
+  roomId: number;
+  roomUuid: string;
+  status: TaskStatus;
+  model: LlmModel;
+  startedAt: number;
+};
+
+type AnalysisTaskState = {
+  activeTask: AnalysisTask | null;
+  setActiveTask: (task: AnalysisTask) => void;
+  updateStatus: (status: TaskStatus) => void;
+  clearActiveTask: () => void;
+};
+
+export const useAnalysisTaskStore = create<AnalysisTaskState>((set) => ({
+  activeTask: null,
+  setActiveTask: (task) => set({ activeTask: task }),
+  updateStatus: (status) =>
+    set((state) => (state.activeTask ? { activeTask: { ...state.activeTask, status } } : state)),
+  clearActiveTask: () => set({ activeTask: null }),
+}));


### PR DESCRIPTION
## 📌 작업한 내용

- 분석 진행 상태를 방 목록/카드/페이지에 반영
- LLM 방 목록 UI 일부 정리

## 🔍 참고 사항

- 분석 작업 상태는 analysisTaskStore에서 관리
- 워처 컴포넌트가 상태를 갱신하며 목록/카드에 반영됩니다

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

Ref #28 

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
