### PR TITLE
[#28] 분석 중 채팅방 임시 생성 및 목록 표시

### DIFF
--- a/src/components/llm/rooms/LlmRoomList.tsx
+++ b/src/components/llm/rooms/LlmRoomList.tsx
@@ -9,6 +9,7 @@ type Props = {
   activeAnalysisRoomId?: number | null;
   onEnterRoom: (roomId: string, numericId: number) => void;
   onDeleteRoom: (roomId: string) => void;
+  onAnalyzingRoomClick?: (roomId: string, numericId: number) => void;
 };
 
 export default function LlmRoomList({
@@ -16,6 +17,7 @@ export default function LlmRoomList({
   activeAnalysisRoomId,
   onEnterRoom,
   onDeleteRoom,
+  onAnalyzingRoomClick,
 }: Props) {
   return (
     <div className="flex flex-col gap-4">
@@ -25,6 +27,7 @@ export default function LlmRoomList({
           room={room}
           isAnalyzing={activeAnalysisRoomId === room.numericId}
           onEnter={() => onEnterRoom(room.id, room.numericId)}
+          onAnalyzingClick={() => onAnalyzingRoomClick?.(room.id, room.numericId)}
           onDelete={onDeleteRoom}
         />
       ))}

--- a/src/components/llm/rooms/LlmRoomListItem.tsx
+++ b/src/components/llm/rooms/LlmRoomListItem.tsx
@@ -8,16 +8,29 @@ type Props = {
   room: LlmRoom;
   isAnalyzing?: boolean;
   onEnter?: () => void;
+  onAnalyzingClick?: () => void;
   onDelete?: (roomId: string) => void;
 };
 
-export default function LlmRoomListItem({ room, isAnalyzing, onEnter, onDelete }: Props) {
+export default function LlmRoomListItem({
+  room,
+  isAnalyzing,
+  onEnter,
+  onAnalyzingClick,
+  onDelete,
+}: Props) {
   return (
     <div className="rounded-2xl border bg-white p-4 shadow-sm">
       <div className="flex items-center justify-between gap-3">
         <button
           type="button"
-          onClick={() => onEnter?.()}
+          onClick={() => {
+            if (isAnalyzing) {
+              onAnalyzingClick?.();
+              return;
+            }
+            onEnter?.();
+          }}
           className="flex min-w-0 flex-1 flex-col text-left"
         >
           <div className="flex min-w-0 items-center gap-2">

--- a/src/lib/llm/analysisTaskStore.ts
+++ b/src/lib/llm/analysisTaskStore.ts
@@ -8,6 +8,7 @@ type AnalysisTask = {
   taskId: number;
   roomId: number;
   roomUuid: string;
+  roomTitle: string;
   status: TaskStatus;
   model: LlmModel;
   startedAt: number;

--- a/src/lib/utils/llm.ts
+++ b/src/lib/utils/llm.ts
@@ -20,17 +20,7 @@ export type UIMessage = {
   status?: MessageStatus;
 };
 
-export function mapAiChatRoomToLlmRoom(room: AiChatRoom): LlmRoom {
-  return {
-    id: room.roomUuid,
-    numericId: room.roomId,
-    title: room.title,
-    updatedAt: formatUpdatedAt(room.updatedAt),
-    storage: getRoomStorageMode(room.roomUuid),
-  };
-}
-
-function formatUpdatedAt(isoString: string): string {
+export function formatUpdatedAt(isoString: string): string {
   const date = new Date(isoString);
   const now = new Date();
   const diffMs = now.getTime() - date.getTime();
@@ -58,6 +48,16 @@ function formatUpdatedAt(isoString: string): string {
   }
 
   return `${date.getFullYear()}.${date.getMonth() + 1}.${date.getDate()}`;
+}
+
+export function mapAiChatRoomToLlmRoom(room: AiChatRoom): LlmRoom {
+  return {
+    id: room.roomUuid,
+    numericId: room.roomId,
+    title: room.title,
+    updatedAt: formatUpdatedAt(room.updatedAt),
+    storage: getRoomStorageMode(room.roomUuid),
+  };
 }
 
 const S3_BASE_URL = process.env.NEXT_PUBLIC_S3_URL ?? '';

--- a/src/screens/llm/LlmAnalysisPage.tsx
+++ b/src/screens/llm/LlmAnalysisPage.tsx
@@ -58,7 +58,7 @@ export default function LlmAnalysisPage({ roomId, numericRoomId: propNumericRoom
   const imageInputRef = useRef<HTMLInputElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const { activeTask, setActiveTask } = useAnalysisTaskStore();
+  const { activeTask, setActiveTask, clearActiveTask } = useAnalysisTaskStore();
   const isAnalysisActive =
     activeTask !== null && activeTask.status !== 'COMPLETED' && activeTask.status !== 'FAILED';
 
@@ -217,8 +217,10 @@ export default function LlmAnalysisPage({ roomId, numericRoomId: propNumericRoom
     setIsLoading(true);
 
     try {
+      const startedAt = Date.now();
       let numericRoomId = propNumericRoomId || 0;
       let roomUuid = roomId;
+      let roomTitle = 'AI 분석';
 
       if (roomId === 'new') {
         const createResult = await createRoom();
@@ -228,6 +230,26 @@ export default function LlmAnalysisPage({ roomId, numericRoomId: propNumericRoom
         const createJson = createResult.json as ApiResponse<CreateRoomResponse>;
         numericRoomId = createJson.data.roomId;
         roomUuid = createJson.data.roomUuid;
+        roomTitle = createJson.data.title || 'AI 분석';
+        setActiveTask({
+          taskId: 0,
+          roomId: numericRoomId,
+          roomUuid,
+          roomTitle,
+          status: 'PENDING',
+          model: form.model,
+          startedAt,
+        });
+      } else {
+        setActiveTask({
+          taskId: 0,
+          roomId: numericRoomId,
+          roomUuid,
+          roomTitle,
+          status: 'PENDING',
+          model: form.model,
+          startedAt,
+        });
       }
 
       // 이력서 파일 업로드 (PDF 또는 이미지)
@@ -307,12 +329,14 @@ export default function LlmAnalysisPage({ roomId, numericRoomId: propNumericRoom
         taskId,
         roomId: numericRoomId,
         roomUuid,
+        roomTitle,
         status: analysisJson.data.status ?? 'PENDING',
         model: form.model,
-        startedAt: Date.now(),
+        startedAt,
       });
     } catch (err) {
       setIsLoading(false);
+      clearActiveTask();
       toast(err instanceof Error ? err.message : '분석 요청 중 오류가 발생했습니다.');
     }
   }, [
@@ -327,6 +351,7 @@ export default function LlmAnalysisPage({ roomId, numericRoomId: propNumericRoom
     propNumericRoomId,
     isAnalysisActive,
     setActiveTask,
+    clearActiveTask,
   ]);
 
   return (


### PR DESCRIPTION
## 📌 작업한 내용

- 분석 시작 시 방 생성 응답을 받은 즉시(메시지 저장 전) activeTask에 방 정보(roomId, roomUuid, roomTitle,
    startedAt)를 저장
- 대화 목록 렌더링 시 실제 목록에 해당 방이 아직 없으면, 임시 방을 최상단에 삽입해 “대화 없음” 화면 대신 목록이 보이도록 처리
- 삽입된 임시 방은 “분석 중” 라벨이 표시되고, 클릭 시 토스트만 뜨며 진입은 차단됨
- 분석 완료/실패 시 전역 상태가 정리되면서 임시 방 표시 및 차단이 해제됨

## 🔍 참고 사항
- 서버에 분석 결과 메시지가 저장되기 전에도 UX상 목록이 먼저 보이도록 하기 위한 낙관적 처리입니다.

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

Ref #28 

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
