### PR TITLE
[#82] 날짜 선택 시 일정 목록 필터링

### DIFF
--- a/src/app/(app)/calendar/page.tsx
+++ b/src/app/(app)/calendar/page.tsx
@@ -319,14 +319,6 @@ export default function CalendarPage() {
     [fetchDetail],
   );
 
-  const sortedEvents = useMemo(() => {
-    return [...events].sort((a, b) => {
-      const startA = a.start ? new Date(a.start as string | number | Date).getTime() : 0;
-      const startB = b.start ? new Date(b.start as string | number | Date).getTime() : 0;
-      return startA - startB;
-    });
-  }, [events]);
-
   const baseTitle = formatDateLabel(currentStart ?? new Date());
   const currentTitle =
     viewMode === 'week' && currentStart
@@ -336,6 +328,35 @@ export default function CalendarPage() {
     () => (selectedDate ? toLocalDate(selectedDate) : undefined),
     [selectedDate],
   );
+  const filteredEvents = useMemo(() => {
+    if (!selectedDateFilter) return events;
+
+    const targetKey = selectedDateFilter.replace(/-/g, '');
+
+    return events.filter((event) => {
+      if (!event.start) return false;
+
+      const startDate = toLocalDate(new Date(event.start as string | number | Date));
+      const endDate = event.end
+        ? toLocalDate(new Date(event.end as string | number | Date))
+        : startDate;
+
+      const startKey = startDate.replace(/-/g, '');
+      const endKey = endDate.replace(/-/g, '');
+
+      const rangeStart = startKey <= endKey ? startKey : endKey;
+      const rangeEnd = startKey <= endKey ? endKey : startKey;
+
+      return targetKey >= rangeStart && targetKey <= rangeEnd;
+    });
+  }, [events, selectedDateFilter]);
+  const sortedEvents = useMemo(() => {
+    return [...filteredEvents].sort((a, b) => {
+      const startA = a.start ? new Date(a.start as string | number | Date).getTime() : 0;
+      const startB = b.start ? new Date(b.start as string | number | Date).getTime() : 0;
+      return startA - startB;
+    });
+  }, [filteredEvents]);
 
   return (
     <main className="calendar-shell pb-8">


### PR DESCRIPTION
## 📌 작업한 내용

  - 캘린더에서 날짜 선택 시 해당 날짜 일정만 목록에 필터링되도록 수정
  - 동일 날짜 재클릭 시 필터 해제되어 전체 일정 다시 표시되도록 개선

## 🔍 참고 사항

  - 일정 목록 필터링 로직이 `src/app/(app)/calendar/page.tsx`에 추가됨

## 🖼️ 스크린샷

<img width="1512" height="821" alt="스크린샷 2026-01-31 오후 6 56 32" src="https://github.com/user-attachments/assets/bb4af696-d5b2-4fa0-9a3d-a1b3f0ff487a" />
<img width="1512" height="821" alt="스크린샷 2026-01-31 오후 6 56 39" src="https://github.com/user-attachments/assets/2ef46484-0b84-417f-9991-ba48af82e6ab" />


## 🔗 관련 이슈

Ref #82 

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
