### PR TITLE
[#96] 채팅 자동 스크롤 정책 개선 및 최신 메시지 이동 버튼

### DIFF
--- a/src/components/llm/chat/LlmMessageList.tsx
+++ b/src/components/llm/chat/LlmMessageList.tsx
@@ -273,7 +273,8 @@ export default function LlmMessageList({
     if (!container) return;
 
     const bottomThreshold = 120;
-    const distanceFromBottom = container.scrollHeight - (container.scrollTop + container.clientHeight);
+    const distanceFromBottom =
+      container.scrollHeight - (container.scrollTop + container.clientHeight);
     const isNearBottom = distanceFromBottom <= bottomThreshold;
     isNearBottomRef.current = isNearBottom;
     setShowJumpToLatest((prev) => (isNearBottom ? false : prev));
@@ -310,7 +311,8 @@ export default function LlmMessageList({
     if (!container) return;
 
     const bottomThreshold = 120;
-    const distanceFromBottom = container.scrollHeight - (container.scrollTop + container.clientHeight);
+    const distanceFromBottom =
+      container.scrollHeight - (container.scrollTop + container.clientHeight);
     isNearBottomRef.current = distanceFromBottom <= bottomThreshold;
 
     if (ignoreNextAutoScrollRef.current) {


### PR DESCRIPTION
## 📌 작업한 내용

  - 채팅 메시지 리스트에서 하단 근처일 때만 자동 스크롤되도록 개선
  - 사용자가 위쪽에 있을 때 새 메시지가 오면 “최근 메시지로 이동” 버튼 노출
  - 과거 메시지 로딩 시 스크롤 유지 로직 보강

## 🔍 참고 사항

  - 하단 근처 기준은 120px로 설정됨(필요 시 조정 가능)

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

Ref #96 

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
