### PR TITLE
[#98] 채팅방 스크롤 동작 개선

### DIFF
--- a/src/components/llm/chat/LlmMessageList.tsx
+++ b/src/components/llm/chat/LlmMessageList.tsx
@@ -337,15 +337,19 @@ export default function LlmMessageList({
     }
 
     if (messages.length > prevMessageCountRef.current) {
-      if (isNearBottomRef.current) {
-        container.scrollTop = container.scrollHeight;
+      const newMessages = messages.slice(prevMessageCountRef.current);
+      const hasUserMessage = newMessages.some((m) => m.role === 'USER');
+      if (hasUserMessage || isNearBottomRef.current) {
+        requestAnimationFrame(() => {
+          container.scrollTop = container.scrollHeight;
+        });
       } else {
         queueMicrotask(() => setShowJumpToLatest(true));
       }
     }
 
     prevMessageCountRef.current = messages.length;
-  }, [messages.length]);
+  }, [messages]);
 
   return (
     <div className="relative min-h-0 flex-1">


### PR DESCRIPTION
## 📌 작업한 내용

  - 채팅방 진입 시 마지막 메시지로 자동 스크롤                             
  - 사용자가 메시지 전송 시 맨 아래로 자동 이동                            
  - 메시지 입력창 및 면접모드 버튼 하단 고정 (min-h-0 추가)                
  - effect 내 setState 호출 lint 에러 수정 (queueMicrotask 사용)

## 🔍 참고 사항

  - `requestAnimationFrame`을 사용하여 DOM 렌더링 후 스크롤 처리           
  - 새로 추가된 메시지 중 USER가 있으면 스크롤 위치와 관계없이 하단 이동

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

Ref #98 

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
