### PR TITLE
[#110] 면접 진행 중 이탈 차단

### DIFF
--- a/src/components/layout/AppFrame.tsx
+++ b/src/components/layout/AppFrame.tsx
@@ -46,6 +46,7 @@ export default function AppFrame({
   const isBottomNavVisible = true;
   const [isAuthed, setIsAuthed] = useState<boolean | null>(null);
   const [isNavigationBlocked, setIsNavigationBlocked] = useState(false);
+  const [blockMessage, setBlockMessage] = useState('답변 생성 중에는 이동할 수 없습니다.');
 
   useEffect(() => {
     setOptions(defaultOptions);
@@ -78,7 +79,7 @@ export default function AppFrame({
     const handlePopState = () => {
       if (!isNavigationBlocked) return;
       window.history.pushState(null, '', window.location.href);
-      toast('답변 생성 중에는 이동할 수 없습니다.');
+      toast(blockMessage);
     };
 
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
@@ -95,7 +96,7 @@ export default function AppFrame({
       window.removeEventListener('popstate', handlePopState);
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
-  }, [isNavigationBlocked]);
+  }, [blockMessage, isNavigationBlocked]);
 
   const requestNavigation = useCallback(
     (action: () => void) => {
@@ -103,9 +104,9 @@ export default function AppFrame({
         action();
         return;
       }
-      toast('답변 생성 중에는 이동할 수 없습니다.');
+      toast(blockMessage);
     },
-    [isNavigationBlocked],
+    [blockMessage, isNavigationBlocked],
   );
 
   return isAuthed ? (
@@ -121,6 +122,8 @@ export default function AppFrame({
         value={{
           isBlocked: isNavigationBlocked,
           setBlocked: setIsNavigationBlocked,
+          blockMessage,
+          setBlockMessage,
           requestNavigation,
         }}
       >

--- a/src/components/layout/NavigationGuardContext.tsx
+++ b/src/components/layout/NavigationGuardContext.tsx
@@ -5,6 +5,8 @@ import { createContext, useContext } from 'react';
 type NavigationGuardContextValue = {
   isBlocked: boolean;
   setBlocked: (blocked: boolean) => void;
+  blockMessage: string;
+  setBlockMessage: (message: string) => void;
   requestNavigation: (action: () => void) => void;
 };
 
@@ -17,6 +19,8 @@ export function useNavigationGuard(): NavigationGuardContextValue {
   return {
     isBlocked: false,
     setBlocked: () => {},
+    blockMessage: '답변 생성 중에는 이동할 수 없습니다.',
+    setBlockMessage: () => {},
     requestNavigation: (action: () => void) => action(),
   };
 }

--- a/src/screens/llm/LlmChatPage.tsx
+++ b/src/screens/llm/LlmChatPage.tsx
@@ -76,7 +76,7 @@ export default function LlmChatPage({ roomId: _roomId, numericRoomId, initialMod
   const [isSending, setIsSending] = useState(false);
   const [streamingAiId, setStreamingAiId] = useState<string | null>(null);
   const notifiedDeletedRef = useRef(false);
-  const { setBlocked } = useNavigationGuard();
+  const { setBlocked, setBlockMessage } = useNavigationGuard();
 
   const errorStatus = (error as Error & { status?: number })?.status;
   const errorMessage = (error as Error | undefined)?.message ?? '';
@@ -119,9 +119,25 @@ export default function LlmChatPage({ roomId: _roomId, numericRoomId, initialMod
   }, [isDeletedRoom]);
 
   useEffect(() => {
-    setBlocked(Boolean(streamingAiId));
+    const isInterviewInProgress =
+      interviewUIState === 'starting' ||
+      interviewUIState === 'active' ||
+      interviewUIState === 'ending';
+    const shouldBlock = Boolean(streamingAiId) || isInterviewInProgress;
+
+    if (shouldBlock) {
+      setBlockMessage(
+        streamingAiId
+          ? '답변 생성 중에는 이동할 수 없습니다.'
+          : '면접 진행 중에는 이동할 수 없습니다.',
+      );
+    } else {
+      setBlockMessage('답변 생성 중에는 이동할 수 없습니다.');
+    }
+
+    setBlocked(shouldBlock);
     return () => setBlocked(false);
-  }, [setBlocked, streamingAiId]);
+  }, [interviewUIState, setBlocked, setBlockMessage, streamingAiId]);
 
   const handleEndInterview = useCallback(
     async (options?: { userMessageId?: string }) => {


### PR DESCRIPTION
## 📌 작업한 내용

  - 면접 진행 중(시작/진행/종료)에도 네비게이션 이탈을 차단하도록 가드 로직 확장
  - 상태에 따라 차단 안내 문구를 구분 표시

## 🔍 참고 사항

  - 스트리밍 중: 답변 생성 중에는 이동할 수 없습니다.
  - 면접 진행 중: 면접 진행 중에는 이동할 수 없습니다.

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

Ref #110 

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
