### PR TITLE
[#137] 면접 평가 영역에 면접 끝내기 버튼 추가 및 액션 비활성화 처리

### DIFF
--- a/src/components/llm/chat/LlmMessageList.tsx
+++ b/src/components/llm/chat/LlmMessageList.tsx
@@ -16,7 +16,9 @@ type Props = {
   onDeleteFailed?: (messageId: string) => void;
   retryEvaluationMessageId?: string | null;
   onRetryEvaluation?: (messageId: string) => void;
+  onFinishInterview?: (messageId: string) => void;
   isRetryEvaluationLoading?: boolean;
+  isInterviewEvaluationActionsDisabled?: boolean;
 };
 
 function TypingIndicator() {
@@ -254,7 +256,9 @@ export default function LlmMessageList({
   onDeleteFailed,
   retryEvaluationMessageId,
   onRetryEvaluation,
+  onFinishInterview,
   isRetryEvaluationLoading = false,
+  isInterviewEvaluationActionsDisabled = false,
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const prevScrollHeightRef = useRef<number>(0);
@@ -481,15 +485,29 @@ export default function LlmMessageList({
                     m.isInterviewEvaluation &&
                     m.id === retryEvaluationMessageId &&
                     onRetryEvaluation ? (
-                      <div className="mt-2">
+                      <div className="mt-2 flex items-center gap-2">
                         <button
                           type="button"
                           onClick={() => onRetryEvaluation(m.id)}
-                          disabled={isRetryEvaluationLoading}
+                          disabled={
+                            isRetryEvaluationLoading || isInterviewEvaluationActionsDisabled
+                          }
                           className="rounded-lg border border-[#05C075] bg-white px-2.5 py-1.5 text-[11px] font-semibold text-[#05C075] hover:bg-[#05C075]/5 disabled:cursor-not-allowed disabled:opacity-50"
                         >
                           면접 평가 다시받기
                         </button>
+                        {onFinishInterview ? (
+                          <button
+                            type="button"
+                            onClick={() => onFinishInterview(m.id)}
+                            disabled={
+                              isRetryEvaluationLoading || isInterviewEvaluationActionsDisabled
+                            }
+                            className="rounded-lg border border-neutral-300 bg-white px-2.5 py-1.5 text-[11px] font-semibold text-neutral-700 hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-50"
+                          >
+                            면접 끝내기
+                          </button>
+                        ) : null}
                       </div>
                     ) : null}
                   </div>

--- a/src/screens/llm/LlmChatPage.tsx
+++ b/src/screens/llm/LlmChatPage.tsx
@@ -75,6 +75,9 @@ export default function LlmChatPage({ roomId: _roomId, numericRoomId, initialMod
   const [model] = useState<LlmModel>(() => parseModel(initialModel));
   const [isSending, setIsSending] = useState(false);
   const [isRetryingEvaluation, setIsRetryingEvaluation] = useState(false);
+  const [finishedEvaluationMessageId, setFinishedEvaluationMessageId] = useState<string | null>(
+    null,
+  );
   const [streamingAiId, setStreamingAiId] = useState<string | null>(null);
   const notifiedDeletedRef = useRef(false);
   const { setBlocked, setBlockMessage } = useNavigationGuard();
@@ -604,6 +607,18 @@ export default function LlmChatPage({ roomId: _roomId, numericRoomId, initialMod
     void handleEndInterview({ retry: true, interviewId: targetInterviewId });
   }, [handleEndInterview, latestInterviewEvaluationMessage]);
 
+  const handleFinishInterview = useCallback((messageId: string) => {
+    setFinishedEvaluationMessageId(messageId);
+    setInterviewSession(null);
+    setInterviewUIState('idle');
+  }, []);
+
+  const isInterviewEvaluationActionsDisabled =
+    (latestInterviewEvaluationMessage?.id !== null &&
+      latestInterviewEvaluationMessage?.id !== undefined &&
+      latestInterviewEvaluationMessage.id === finishedEvaluationMessageId) ||
+    isRetryingEvaluation;
+
   const isComposerDisabled =
     isSending ||
     Boolean(streamingAiId) ||
@@ -663,7 +678,9 @@ export default function LlmChatPage({ roomId: _roomId, numericRoomId, initialMod
             interviewUIState === 'idle' ? (latestInterviewEvaluationMessage?.id ?? null) : null
           }
           onRetryEvaluation={() => handleRetryInterviewEvaluation()}
+          onFinishInterview={handleFinishInterview}
           isRetryEvaluationLoading={isRetryingEvaluation}
+          isInterviewEvaluationActionsDisabled={isInterviewEvaluationActionsDisabled}
         />
 
         <div className="bg-white px-3 py-2">


### PR DESCRIPTION
## 📌 작업한 내용

 - 면접 평가 메시지 하단에 면접 끝내기 버튼 추가
  - 면접 평가 다시받기/면접 끝내기 버튼 비활성화 로직 추가
  - 면접 끝내기 클릭 시 면접 세션 종료 처리 후 일반 대화 모드(idle)로 전환
  - 관련 상태/핸들러를 LlmChatPage에서 LlmMessageList로 props 전달하도록 확장

## 🔍 참고 사항

 - 변경 파일은 `src/components/llm/chat/LlmMessageList.tsx`, `src/screens/llm/LlmChatPage.tsx` 입니다.
  - 면접 끝내기는 최신 면접 평가 메시지 액션 영역에서만 동작합니다.
  - 면접 끝내기 클릭 후에는 해당 평가 액션 버튼들이 비활성화됩니다.
  - 평가 재요청 진행 중(isRetryingEvaluation)에도 액션 버튼이 비활성화됩니다.

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

Ref #137 

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
