### PR TITLE
[#142] style: 채팅 상세 레이아웃 개선

### DIFF
--- a/src/screens/chat/ChatRoomPage.tsx
+++ b/src/screens/chat/ChatRoomPage.tsx
@@ -205,6 +205,7 @@ export default function ChatRoomPage({ roomId, mode = 'room' }: ChatRoomPageProp
   const isMessageInputComposingRef = useRef(false);
   const initialScrollResyncTimerRef = useRef<number | null>(null);
   const hasInitialScrollRef = useRef(false);
+  const hasNoUnreadInitialBottomResyncedRef = useRef(false);
   const isLoadingOlderRef = useRef(false);
   const prevScrollHeightRef = useRef(0);
   const hasPatchedOnEntryRef = useRef(false);
@@ -683,6 +684,7 @@ export default function ChatRoomPage({ roomId, mode = 'room' }: ChatRoomPageProp
 
   useEffect(() => {
     hasInitialScrollRef.current = false;
+    hasNoUnreadInitialBottomResyncedRef.current = false;
     isLoadingOlderRef.current = false;
     prevScrollHeightRef.current = 0;
     hasPatchedOnEntryRef.current = false;
@@ -769,6 +771,39 @@ export default function ChatRoomPage({ roomId, mode = 'room' }: ChatRoomPageProp
       isLoadingOlderRef.current = false;
     }
   }, [messages, unreadStartIndex]);
+
+  useEffect(() => {
+    if (!hasInitialScrollRef.current) {
+      return;
+    }
+
+    if (hasNoUnreadInitialBottomResyncedRef.current) {
+      return;
+    }
+
+    if (messages.length === 0 || unreadStartIndex >= 0) {
+      return;
+    }
+
+    const container = messageListRef.current;
+    if (!container) {
+      return;
+    }
+
+    hasNoUnreadInitialBottomResyncedRef.current = true;
+
+    const timerId = window.setTimeout(() => {
+      const currentContainer = messageListRef.current;
+      if (!currentContainer) {
+        return;
+      }
+      currentContainer.scrollTop = currentContainer.scrollHeight;
+    }, 150);
+
+    return () => {
+      window.clearTimeout(timerId);
+    };
+  }, [messages.length, unreadStartIndex]);
 
   useEffect(() => {
     if (roomId === null || isMessagesLoading || isMessagesError || latestMessageId === null) {


### PR DESCRIPTION
## 📌 작업한 내용

  - 채팅방 상세(ChatRoomPage) UI/UX 개선
      - 1:1 채팅에서 상대 메시지 옆에 프로필 아바타 표시
      - 입력창 UI 정리 (파일 버튼 / textarea / 전송 버튼 정렬, 글자수 카운터 위치 조정)
      - 긴 숫자/영문(공백 없는 문자열) 메시지가 버블 밖으로 넘치지 않도록 줄바꿈 처리 개선
  - 채팅방 설정 화면 UI 개선
      - 내부 가로 여백 확대 및 콘텐츠 폭 조정 (답답함 완화)
      - 최근 이미지 썸네일 그리드 4열 -> 2열 변경
      - 액션 버튼(닫기/저장/채팅방 나가기)을 화면 하단 영역에 배치
      - 상단 채팅방 설정 텍스트 제거
      - 알림 토글 ON 상태 / 저장 버튼을 초록색 테마로 변경
  - 채팅방 초기 진입 스크롤 보정
      - 여기까지 읽었습니다 구분선이 없는 경우 최초 진입 시 최신 메시지(하단)로 보이도록 초기 스크롤 resync 로직 추가
  - FILE(PDF) 메시지 디버깅 로그 추가
      - 송신 payload -> STOMP 수신 -> 캐시 반영 -> FILE 렌더 분기 추적용 로그 추가
      - lint 경고 방지를 위해 console.warn 사용

## 🔍 참고 사항

  - 이번 커밋 범위는 `src/screens/chat/ChatRoomPage.ts`x 단일 파일 변경입니다.
  - FILE 메시지 디버깅 로그가 포함되어 있습니다 ([CHAT][...]prefix, console.warn).
      - 원인 분석 후 정리(제거) 예정이라면 후속 커밋으로 분리 권장
  - 채팅방 설정 화면은 레이아웃/버튼 위치/색상 변경이 함께 들어가 있어 UI 변경 범위가 큽니다.

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

Ref #142 

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
