### PR TITLE
[#173] refactor: 평가 액션 disabled 조건 파생 boolean으로 분리

### DIFF
--- a/src/lib/hooks/llm/useInterviewEvaluation.ts
+++ b/src/lib/hooks/llm/useInterviewEvaluation.ts
@@ -25,11 +25,12 @@ export function useInterviewEvaluation(
     return null;
   }, [messages]);
 
-  const isActionsDisabled =
-    (latestInterviewEvaluationMessage?.id !== null &&
-      latestInterviewEvaluationMessage?.id !== undefined &&
-      latestInterviewEvaluationMessage.id === finishedEvaluationMessageId) ||
-    isRetryingEvaluation;
+  const isEvaluationAlreadyFinished =
+    latestInterviewEvaluationMessage?.id !== null &&
+    latestInterviewEvaluationMessage?.id !== undefined &&
+    latestInterviewEvaluationMessage.id === finishedEvaluationMessageId;
+
+  const isActionsDisabled = isEvaluationAlreadyFinished || isRetryingEvaluation;
 
   const retryEvaluation = useCallback(() => {
     const targetInterviewId = latestInterviewEvaluationMessage?.interviewId;


### PR DESCRIPTION
## 📌 작업한 내용

  useInterviewEvaluation.ts의 isActionsDisabled 조건식을 파생 boolean으로 분리했습니다.

  - isEvaluationAlreadyFinished 추출 — 이미 완료된 평가인지 사유를 이름으로 드러냄                      
  - isActionsDisabled → isEvaluationAlreadyFinished || isRetryingEvaluation 로 교체 — disabled 사유 2개가 한눈에 읽힘                                                                                             
  - 동작 변경 없음

## 🔍 참고 사항

  - 순수 가독성 개선이며 동작 변경 없습니다.
  - != null 단일 체크로 교체하려 했으나 ESLint eqeqeq 규칙으로 불가, !== null && !== undefined 유지했습니다.

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

Ref #173 

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
- [ ] (채팅) `/api/chatrooms` pagination에서 서버 cursor 재사용 원칙 준수 확인
