### PR TITLE
[#175] refactor: 가독성/유지보수성 개선: constants 정리 및 ChatRoomPage 로직 분리

### DIFF
--- a/src/constants/board.ts
+++ b/src/constants/board.ts
@@ -16,3 +16,13 @@ export const BOARD_SORT_OPTIONS = [
 ] as const satisfies readonly { key: BoardSort; label: string }[];
 
 export const POPULAR_MIN_LIKES = 500;
+
+export const BOARD_PAGE_SIZE = 10;
+export const FOLLOWINGS_FETCH_SIZE = 100;
+export const PULL_MAX = 120;
+export const PULL_THRESHOLD = 72;
+
+export const RECENT_SEARCH_STORAGE_KEY = 'devths_board_recent_searches';
+export const MAX_RECENT_SEARCH_COUNT = 10;
+export const SEARCH_PAGE_SIZE = 20;
+export const SEARCH_QUERY_PARAM_KEY = 'q';

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -1,0 +1,26 @@
+export const MESSAGE_PAGE_SIZE = 20;
+export const LONG_MESSAGE_THRESHOLD = 300;
+export const TOP_FETCH_THRESHOLD = 80;
+export const BOTTOM_CONFIRM_THRESHOLD = 32;
+export const DELETE_LONG_PRESS_MS = 2000;
+export const MESSAGE_SEND_DESTINATION = '/app/chat/message';
+export const MAX_IMAGE_ATTACHMENTS_PER_PICK = 9;
+export const MAX_ATTACHMENT_FILE_SIZE_BYTES = 5 * 1024 * 1024;
+export const ALLOWED_IMAGE_MIME_TYPES = new Set([
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/webp',
+]);
+export const ALLOWED_FILE_MIME_TYPES = new Set([
+  'application/pdf',
+  'application/x-pdf',
+  'application/acrobat',
+  'applications/vnd.pdf',
+  'text/pdf',
+]);
+export const PDF_FILE_EXTENSION_REGEX = /\.pdf$/i;
+export const ROOM_PAGE_SIZE = 10;
+export const ROOM_NAME_MAX_LENGTH = 6;
+export const MIN_NICKNAME_LENGTH = 2;
+export const MAX_NICKNAME_LENGTH = 10;

--- a/src/constants/llm.ts
+++ b/src/constants/llm.ts
@@ -1,0 +1,5 @@
+import type { LlmModel } from '@/types/llm';
+
+export const DEFAULT_LLM_MODEL: LlmModel = 'GEMINI';
+export const BLOCK_MSG_STREAMING = '답변 생성 중에는 이동할 수 없습니다.';
+export const BLOCK_MSG_INTERVIEW = '면접 진행 중에는 이동할 수 없습니다.';

--- a/src/lib/hooks/chat/useAttachmentHandler.ts
+++ b/src/lib/hooks/chat/useAttachmentHandler.ts
@@ -1,0 +1,215 @@
+import { type QueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useRef, useState, type ChangeEvent } from 'react';
+
+import {
+  ALLOWED_FILE_MIME_TYPES,
+  ALLOWED_IMAGE_MIME_TYPES,
+  MAX_ATTACHMENT_FILE_SIZE_BYTES,
+  MAX_IMAGE_ATTACHMENTS_PER_PICK,
+  MESSAGE_PAGE_SIZE,
+  MESSAGE_SEND_DESTINATION,
+  PDF_FILE_EXTENSION_REGEX,
+} from '@/constants/chat';
+import { fetchChatMessages } from '@/lib/api/chatMessages';
+import { applyRealtimeRoomMessage } from '@/lib/chat/realtimeMessageCache';
+import { chatStompManager } from '@/lib/chat/stompManager';
+import { toast } from '@/lib/toast/store';
+import { uploadFile } from '@/lib/upload/uploadFile';
+
+import type { SendChatMessagePayload } from '@/lib/api/chatMessages';
+
+type Params = {
+  roomId: number | null;
+  queryClient: QueryClient;
+};
+
+function isPdfFile(file: File): boolean {
+  const mimeType = file.type.trim().toLowerCase();
+  if (mimeType && ALLOWED_FILE_MIME_TYPES.has(mimeType)) {
+    return true;
+  }
+
+  return PDF_FILE_EXTENSION_REGEX.test(file.name);
+}
+
+function resolveAttachmentMimeType(file: File, isImageAttachment: boolean): string {
+  if (isImageAttachment) {
+    return file.type || 'application/octet-stream';
+  }
+
+  // Some environments return empty/variant MIME for PDF. Normalize to application/pdf.
+  return isPdfFile(file) ? 'application/pdf' : file.type || 'application/octet-stream';
+}
+
+export function useAttachmentHandler({ roomId, queryClient }: Params) {
+  const [isAttachmentUploading, setIsAttachmentUploading] = useState(false);
+  const [isAttachmentPickerOpen, setIsAttachmentPickerOpen] = useState(false);
+  const [attachmentValidationMessage, setAttachmentValidationMessage] = useState<string | null>(
+    null,
+  );
+  const imageAttachmentInputRef = useRef<HTMLInputElement>(null);
+  const fileAttachmentInputRef = useRef<HTMLInputElement>(null);
+  const attachmentEchoFallbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (attachmentEchoFallbackTimerRef.current !== null) {
+      clearTimeout(attachmentEchoFallbackTimerRef.current);
+      attachmentEchoFallbackTimerRef.current = null;
+    }
+  }, [roomId]);
+
+  const openAttachmentValidationModal = useCallback((message: string) => {
+    setIsAttachmentPickerOpen(false);
+    setAttachmentValidationMessage(message);
+  }, []);
+
+  const handleAttachmentButtonClick = useCallback(() => {
+    if (isAttachmentUploading) {
+      return;
+    }
+
+    setIsAttachmentPickerOpen(true);
+  }, [isAttachmentUploading]);
+
+  const handlePickImageAttachments = useCallback(() => {
+    if (isAttachmentUploading) {
+      return;
+    }
+
+    setIsAttachmentPickerOpen(false);
+    imageAttachmentInputRef.current?.click();
+  }, [isAttachmentUploading]);
+
+  const handlePickFileAttachment = useCallback(() => {
+    if (isAttachmentUploading) {
+      return;
+    }
+
+    setIsAttachmentPickerOpen(false);
+    fileAttachmentInputRef.current?.click();
+  }, [isAttachmentUploading]);
+
+  const handleAttachmentChange = useCallback(
+    async (event: ChangeEvent<HTMLInputElement>) => {
+      const selectedFiles = Array.from(event.target.files ?? []);
+      event.target.value = '';
+
+      if (selectedFiles.length === 0 || roomId === null || isAttachmentUploading) {
+        return;
+      }
+
+      const imageFiles = selectedFiles.filter((file) => ALLOWED_IMAGE_MIME_TYPES.has(file.type));
+      const nonImageFiles = selectedFiles.filter(
+        (file) => !ALLOWED_IMAGE_MIME_TYPES.has(file.type),
+      );
+
+      if (imageFiles.length > 0 && nonImageFiles.length > 0) {
+        openAttachmentValidationModal('이미지와 파일은 동시에 첨부할 수 없습니다.');
+        return;
+      }
+
+      if (imageFiles.length > MAX_IMAGE_ATTACHMENTS_PER_PICK) {
+        openAttachmentValidationModal(
+          `이미지는 한 번에 최대 ${MAX_IMAGE_ATTACHMENTS_PER_PICK}장까지 첨부할 수 있습니다.`,
+        );
+        return;
+      }
+
+      if (nonImageFiles.length > 1) {
+        openAttachmentValidationModal('파일은 한 번에 1개만 첨부할 수 있습니다.');
+        return;
+      }
+
+      for (const file of selectedFiles) {
+        if (file.size > MAX_ATTACHMENT_FILE_SIZE_BYTES) {
+          openAttachmentValidationModal('파일 용량은 5MB 이하만 첨부할 수 있습니다.');
+          return;
+        }
+      }
+
+      if (nonImageFiles.length === 1 && !isPdfFile(nonImageFiles[0]!)) {
+        openAttachmentValidationModal('파일 첨부는 PDF 형식만 지원합니다.');
+        return;
+      }
+
+      setIsAttachmentUploading(true);
+
+      try {
+        for (const file of selectedFiles) {
+          const isImageAttachment = ALLOWED_IMAGE_MIME_TYPES.has(file.type);
+          const normalizedMimeType = resolveAttachmentMimeType(file, isImageAttachment);
+
+          const uploaded = await uploadFile({
+            file,
+            category: 'AI_CHAT_ATTACHMENT',
+            refType: 'CHATROOM',
+            refId: roomId,
+            mimeType: normalizedMimeType,
+          });
+
+          const payload: SendChatMessagePayload = isImageAttachment
+            ? {
+                roomId,
+                type: 'IMAGE',
+                content: null,
+                s3Key: uploaded.s3Key,
+              }
+            : {
+                roomId,
+                type: 'PDF',
+                content: uploaded.s3Key,
+                s3Key: uploaded.s3Key,
+              };
+
+          const published = chatStompManager.publishJson(MESSAGE_SEND_DESTINATION, payload);
+          if (!published) {
+            toast('첨부 메시지 전송에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+            return;
+          }
+
+          // STOMP echo fallback: 백엔드가 FILE/IMAGE 메시지를 브로드캐스트하지 않는 경우
+          // 2초 후 REST API로 최신 메시지를 가져와 캐시에 병합합니다.
+          if (attachmentEchoFallbackTimerRef.current !== null) {
+            clearTimeout(attachmentEchoFallbackTimerRef.current);
+          }
+          const fallbackRoomId = roomId;
+          attachmentEchoFallbackTimerRef.current = setTimeout(() => {
+            attachmentEchoFallbackTimerRef.current = null;
+            void fetchChatMessages(fallbackRoomId, { size: MESSAGE_PAGE_SIZE }).then((result) => {
+              if (!result.ok || !result.json || !('data' in result.json) || !result.json.data) {
+                return;
+              }
+              for (const msg of result.json.data.messages) {
+                applyRealtimeRoomMessage(queryClient, {
+                  roomId: fallbackRoomId,
+                  size: MESSAGE_PAGE_SIZE,
+                  message: msg,
+                });
+              }
+            });
+          }, 2000);
+        }
+      } catch (error) {
+        const err = error as Error;
+        toast(err.message || '파일 업로드에 실패했습니다.');
+      } finally {
+        setIsAttachmentUploading(false);
+      }
+    },
+    [isAttachmentUploading, openAttachmentValidationModal, queryClient, roomId],
+  );
+
+  return {
+    isAttachmentUploading,
+    isAttachmentPickerOpen,
+    setIsAttachmentPickerOpen,
+    attachmentValidationMessage,
+    setAttachmentValidationMessage,
+    imageAttachmentInputRef,
+    fileAttachmentInputRef,
+    handleAttachmentButtonClick,
+    handlePickImageAttachments,
+    handlePickFileAttachment,
+    handleAttachmentChange,
+  };
+}

--- a/src/lib/hooks/chat/useChatScroll.ts
+++ b/src/lib/hooks/chat/useChatScroll.ts
@@ -1,0 +1,226 @@
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
+
+import { BOTTOM_CONFIRM_THRESHOLD, TOP_FETCH_THRESHOLD } from '@/constants/chat';
+import { usePatchLastReadMutation } from '@/lib/hooks/chat/usePatchLastReadMutation';
+
+import type { ChatMessageResponse } from '@/lib/api/chatMessages';
+
+type Params = {
+  roomId: number | null;
+  messages: ChatMessageResponse[];
+  unreadStartIndex: number;
+  serverLastReadMsgId: number | null;
+  latestMessageId: number | null;
+  isMessagesLoading: boolean;
+  isMessagesError: boolean;
+  fetchNextPage: () => void;
+  hasNextPage: boolean | undefined;
+  isFetchingNextPage: boolean;
+};
+
+export function useChatScroll({
+  roomId,
+  messages,
+  unreadStartIndex,
+  serverLastReadMsgId,
+  latestMessageId,
+  isMessagesLoading,
+  isMessagesError,
+  fetchNextPage,
+  hasNextPage,
+  isFetchingNextPage,
+}: Params) {
+  const messageListRef = useRef<HTMLDivElement>(null);
+  const unreadDividerRef = useRef<HTMLDivElement>(null);
+  const initialScrollResyncTimerRef = useRef<number | null>(null);
+  const hasInitialScrollRef = useRef(false);
+  const hasNoUnreadInitialBottomResyncedRef = useRef(false);
+  const isLoadingOlderRef = useRef(false);
+  const prevScrollHeightRef = useRef(0);
+  const hasPatchedOnEntryRef = useRef(false);
+  const lastPatchedMsgIdRef = useRef<number | null>(null);
+
+  const patchLastReadMutation = usePatchLastReadMutation(roomId ?? 0);
+
+  // roomId 변경 시 스크롤 관련 ref 초기화 및 타이머 정리
+  useEffect(() => {
+    if (initialScrollResyncTimerRef.current !== null) {
+      window.clearTimeout(initialScrollResyncTimerRef.current);
+      initialScrollResyncTimerRef.current = null;
+    }
+    hasInitialScrollRef.current = false;
+    hasNoUnreadInitialBottomResyncedRef.current = false;
+    isLoadingOlderRef.current = false;
+    prevScrollHeightRef.current = 0;
+    hasPatchedOnEntryRef.current = false;
+    lastPatchedMsgIdRef.current = null;
+  }, [roomId]);
+
+  // 컴포넌트 언마운트 시 타이머 정리
+  useEffect(() => {
+    return () => {
+      if (initialScrollResyncTimerRef.current !== null) {
+        window.clearTimeout(initialScrollResyncTimerRef.current);
+        initialScrollResyncTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  const patchLastReadOnce = useCallback(
+    (targetMessageId: number) => {
+      if (roomId === null) {
+        return;
+      }
+
+      if (targetMessageId <= 0 || patchLastReadMutation.isPending) {
+        return;
+      }
+
+      if (lastPatchedMsgIdRef.current !== null && targetMessageId <= lastPatchedMsgIdRef.current) {
+        return;
+      }
+
+      patchLastReadMutation.mutate(targetMessageId, {
+        onSuccess: () => {
+          lastPatchedMsgIdRef.current = targetMessageId;
+        },
+      });
+    },
+    [patchLastReadMutation, roomId],
+  );
+
+  // 서버에서 받은 lastReadMsgId로 lastPatchedMsgIdRef 초기화
+  useEffect(() => {
+    if (serverLastReadMsgId === null) {
+      return;
+    }
+
+    if (lastPatchedMsgIdRef.current === null) {
+      lastPatchedMsgIdRef.current = serverLastReadMsgId;
+    }
+  }, [serverLastReadMsgId]);
+
+  // 초기 스크롤 위치 설정 + 이전 메시지 로딩 시 스크롤 높이 보정
+  useLayoutEffect(() => {
+    const container = messageListRef.current;
+    if (!container || messages.length === 0) {
+      return;
+    }
+
+    if (!hasInitialScrollRef.current) {
+      if (unreadStartIndex >= 0 && unreadDividerRef.current) {
+        const dividerTop = unreadDividerRef.current.offsetTop;
+        container.scrollTop = Math.max(0, dividerTop - container.clientHeight * 0.35);
+      } else {
+        container.scrollTop = container.scrollHeight;
+        requestAnimationFrame(() => {
+          const currentContainer = messageListRef.current;
+          if (!currentContainer) {
+            return;
+          }
+          currentContainer.scrollTop = currentContainer.scrollHeight;
+        });
+        if (initialScrollResyncTimerRef.current !== null) {
+          window.clearTimeout(initialScrollResyncTimerRef.current);
+        }
+        initialScrollResyncTimerRef.current = window.setTimeout(() => {
+          const currentContainer = messageListRef.current;
+          if (!currentContainer) {
+            return;
+          }
+          currentContainer.scrollTop = currentContainer.scrollHeight;
+          initialScrollResyncTimerRef.current = null;
+        }, 300);
+      }
+      hasInitialScrollRef.current = true;
+      return;
+    }
+
+    if (isLoadingOlderRef.current) {
+      const newScrollHeight = container.scrollHeight;
+      const scrollDiff = newScrollHeight - prevScrollHeightRef.current;
+      container.scrollTop += scrollDiff;
+      isLoadingOlderRef.current = false;
+    }
+  }, [messages, unreadStartIndex]);
+
+  // 읽지 않은 메시지 없을 때 초기 진입 하단 재동기화
+  useEffect(() => {
+    if (!hasInitialScrollRef.current) {
+      return;
+    }
+
+    if (hasNoUnreadInitialBottomResyncedRef.current) {
+      return;
+    }
+
+    if (messages.length === 0 || unreadStartIndex >= 0) {
+      return;
+    }
+
+    const container = messageListRef.current;
+    if (!container) {
+      return;
+    }
+
+    hasNoUnreadInitialBottomResyncedRef.current = true;
+
+    const timerId = window.setTimeout(() => {
+      const currentContainer = messageListRef.current;
+      if (!currentContainer) {
+        return;
+      }
+      currentContainer.scrollTop = currentContainer.scrollHeight;
+    }, 150);
+
+    return () => {
+      window.clearTimeout(timerId);
+    };
+  }, [messages.length, unreadStartIndex]);
+
+  // 진입 시 최신 메시지 lastRead 패치
+  useEffect(() => {
+    if (roomId === null || isMessagesLoading || isMessagesError || latestMessageId === null) {
+      return;
+    }
+
+    if (hasPatchedOnEntryRef.current) {
+      return;
+    }
+
+    hasPatchedOnEntryRef.current = true;
+    patchLastReadOnce(latestMessageId);
+  }, [isMessagesError, isMessagesLoading, latestMessageId, patchLastReadOnce, roomId]);
+
+  const handleMessageScroll = useCallback(() => {
+    const container = messageListRef.current;
+    if (!container) {
+      return;
+    }
+
+    const distanceFromBottom =
+      container.scrollHeight - (container.scrollTop + container.clientHeight);
+    if (distanceFromBottom <= BOTTOM_CONFIRM_THRESHOLD && latestMessageId !== null) {
+      patchLastReadOnce(latestMessageId);
+    }
+
+    if (!hasNextPage || isFetchingNextPage) {
+      return;
+    }
+
+    if (container.scrollTop > TOP_FETCH_THRESHOLD) {
+      return;
+    }
+
+    prevScrollHeightRef.current = container.scrollHeight;
+    isLoadingOlderRef.current = true;
+    void fetchNextPage();
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage, latestMessageId, patchLastReadOnce]);
+
+  return {
+    messageListRef,
+    unreadDividerRef,
+    handleMessageScroll,
+    patchLastReadOnce,
+  };
+}

--- a/src/lib/utils/chatDate.ts
+++ b/src/lib/utils/chatDate.ts
@@ -1,0 +1,49 @@
+export function parseKstDateTime(value: string): Date {
+  const normalized = value.includes(' ') ? value.replace(' ', 'T') : value;
+  const hasTimezone = /([zZ]|[+-]\d{2}:\d{2})$/.test(normalized);
+  if (hasTimezone) {
+    return new Date(normalized);
+  }
+
+  // Backend chat timestamps are currently serialized without timezone info but represent UTC.
+  return new Date(`${normalized}Z`);
+}
+
+export function formatDateKey(value: string): string {
+  const date = parseKstDateTime(value);
+  if (Number.isNaN(date.getTime())) {
+    return value.slice(0, 10);
+  }
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export function formatStickyDateLabel(value: string): string {
+  const date = parseKstDateTime(value);
+  if (Number.isNaN(date.getTime())) {
+    return value.slice(0, 10);
+  }
+
+  return date.toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    weekday: 'short',
+  });
+}
+
+export function formatMessageTime(value: string): string {
+  const date = parseKstDateTime(value);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+
+  return date.toLocaleTimeString('ko-KR', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+}

--- a/src/screens/board/BoardListPage.tsx
+++ b/src/screens/board/BoardListPage.tsx
@@ -12,7 +12,14 @@ import BoardUserMiniProfile from '@/components/board/BoardUserMiniProfile';
 import { useHeader } from '@/components/layout/HeaderContext';
 import { useNavigationGuard } from '@/components/layout/NavigationGuardContext';
 import ListLoadMoreSentinel from '@/components/llm/rooms/ListLoadMoreSentinel';
-import { BOARD_TAG_MAX, POPULAR_MIN_LIKES } from '@/constants/board';
+import {
+  BOARD_PAGE_SIZE,
+  BOARD_TAG_MAX,
+  FOLLOWINGS_FETCH_SIZE,
+  POPULAR_MIN_LIKES,
+  PULL_MAX,
+  PULL_THRESHOLD,
+} from '@/constants/board';
 import { fetchMyFollowings, fetchUserProfile } from '@/lib/api/users';
 import { getUserIdFromAccessToken } from '@/lib/auth/token';
 import { useBoardListInfiniteQuery } from '@/lib/hooks/boards/useBoardListInfiniteQuery';
@@ -24,11 +31,6 @@ import { toast } from '@/lib/toast/store';
 import { parseBoardDateTime } from '@/lib/utils/board';
 
 import type { BoardSort, BoardTag } from '@/types/board';
-
-const PAGE_SIZE = 10;
-const FOLLOWINGS_FETCH_SIZE = 100;
-const PULL_MAX = 120;
-const PULL_THRESHOLD = 72;
 
 export default function BoardListPage() {
   const router = useRouter();
@@ -54,7 +56,7 @@ export default function BoardListPage() {
 
   const { data, isLoading, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useBoardListInfiniteQuery({
-      size: PAGE_SIZE,
+      size: BOARD_PAGE_SIZE,
       sort,
       tags: selectedTags,
     });

--- a/src/screens/board/BoardSearchPage.tsx
+++ b/src/screens/board/BoardSearchPage.tsx
@@ -7,12 +7,13 @@ import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 're
 import BoardPostCard from '@/components/board/BoardPostCard';
 import { useHeader } from '@/components/layout/HeaderContext';
 import ListLoadMoreSentinel from '@/components/llm/rooms/ListLoadMoreSentinel';
+import {
+  MAX_RECENT_SEARCH_COUNT,
+  RECENT_SEARCH_STORAGE_KEY,
+  SEARCH_PAGE_SIZE,
+  SEARCH_QUERY_PARAM_KEY,
+} from '@/constants/board';
 import { useBoardSearchInfiniteQuery } from '@/lib/hooks/boards/useBoardSearchInfiniteQuery';
-
-const RECENT_SEARCH_STORAGE_KEY = 'devths_board_recent_searches';
-const MAX_RECENT_SEARCH_COUNT = 10;
-const SEARCH_PAGE_SIZE = 20;
-const SEARCH_QUERY_PARAM_KEY = 'q';
 
 type KeywordValidationResult = {
   isValid: boolean;

--- a/src/screens/chat/ChatCreatePage.tsx
+++ b/src/screens/chat/ChatCreatePage.tsx
@@ -8,15 +8,13 @@ import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } fro
 
 import { useHeader } from '@/components/layout/HeaderContext';
 import ListLoadMoreSentinel from '@/components/llm/rooms/ListLoadMoreSentinel';
+import { MAX_NICKNAME_LENGTH, MIN_NICKNAME_LENGTH } from '@/constants/chat';
 import { applyRejoinedRoomUiOverride } from '@/lib/chat/rejoinedRoomUiCache';
 import { useCreatePrivateRoomMutation } from '@/lib/hooks/chat/useCreatePrivateRoomMutation';
 import { useMyFollowingsInfiniteQuery } from '@/lib/hooks/chat/useMyFollowingsInfiniteQuery';
 import { toast } from '@/lib/toast/store';
 
 import type { ChatFollowingSummaryResponse } from '@/lib/api/chatFollowings';
-
-const MIN_NICKNAME_LENGTH = 2;
-const MAX_NICKNAME_LENGTH = 10;
 
 function sortByNickname(a: ChatFollowingSummaryResponse, b: ChatFollowingSummaryResponse) {
   const nicknameCompare = a.nickname.localeCompare(b.nickname, 'ko');

--- a/src/screens/chat/ChatPlaceholderPage.tsx
+++ b/src/screens/chat/ChatPlaceholderPage.tsx
@@ -9,15 +9,13 @@ import { useEffect, useMemo, useRef } from 'react';
 import { useHeader } from '@/components/layout/HeaderContext';
 import { useNavigationGuard } from '@/components/layout/NavigationGuardContext';
 import ListLoadMoreSentinel from '@/components/llm/rooms/ListLoadMoreSentinel';
+import { ROOM_NAME_MAX_LENGTH, ROOM_PAGE_SIZE } from '@/constants/chat';
 import { fetchChatRooms } from '@/lib/api/chatRooms';
 import { chatKeys } from '@/lib/hooks/chat/queryKeys';
 import { useChatRoomsInfiniteQuery } from '@/lib/hooks/chat/useChatRoomsInfiniteQuery';
 
 import type { ChatRoomListResponse } from '@/lib/api/chatRooms';
 import type { RejoinedRoomUiOverrideMap } from '@/lib/chat/rejoinedRoomUiCache';
-
-const ROOM_PAGE_SIZE = 10;
-const ROOM_NAME_MAX_LENGTH = 6;
 
 function parseKstDateTime(value: string): Date {
   const normalized = value.includes(' ') ? value.replace(' ', 'T') : value;

--- a/src/screens/chat/ChatRoomPage.tsx
+++ b/src/screens/chat/ChatRoomPage.tsx
@@ -28,6 +28,19 @@ import {
 import ConfirmModal from '@/components/common/ConfirmModal';
 import { useAppFrame } from '@/components/layout/AppFrameContext';
 import { useHeader } from '@/components/layout/HeaderContext';
+import {
+  ALLOWED_FILE_MIME_TYPES,
+  ALLOWED_IMAGE_MIME_TYPES,
+  BOTTOM_CONFIRM_THRESHOLD,
+  DELETE_LONG_PRESS_MS,
+  LONG_MESSAGE_THRESHOLD,
+  MAX_ATTACHMENT_FILE_SIZE_BYTES,
+  MAX_IMAGE_ATTACHMENTS_PER_PICK,
+  MESSAGE_PAGE_SIZE,
+  MESSAGE_SEND_DESTINATION,
+  PDF_FILE_EXTENSION_REGEX,
+  TOP_FETCH_THRESHOLD,
+} from '@/constants/chat';
 import { fetchChatMessages } from '@/lib/api/chatMessages';
 import { getUserIdFromAccessToken } from '@/lib/auth/token';
 import { applyRealtimeRoomMessage } from '@/lib/chat/realtimeMessageCache';
@@ -52,24 +65,6 @@ type ChatRoomPageProps = Readonly<{
   roomId: number | null;
   mode?: 'room' | 'settings';
 }>;
-
-const MESSAGE_PAGE_SIZE = 20;
-const LONG_MESSAGE_THRESHOLD = 300;
-const TOP_FETCH_THRESHOLD = 80;
-const BOTTOM_CONFIRM_THRESHOLD = 32;
-const DELETE_LONG_PRESS_MS = 2000;
-const MESSAGE_SEND_DESTINATION = '/app/chat/message';
-const MAX_IMAGE_ATTACHMENTS_PER_PICK = 9;
-const MAX_ATTACHMENT_FILE_SIZE_BYTES = 5 * 1024 * 1024;
-const ALLOWED_IMAGE_MIME_TYPES = new Set(['image/jpeg', 'image/jpg', 'image/png', 'image/webp']);
-const ALLOWED_FILE_MIME_TYPES = new Set([
-  'application/pdf',
-  'application/x-pdf',
-  'application/acrobat',
-  'applications/vnd.pdf',
-  'text/pdf',
-]);
-const PDF_FILE_EXTENSION_REGEX = /\.pdf$/i;
 
 function isPdfFile(file: File): boolean {
   const mimeType = file.type.trim().toLowerCase();

--- a/src/screens/chat/ChatRoomPage.tsx
+++ b/src/screens/chat/ChatRoomPage.tsx
@@ -57,6 +57,7 @@ import { usePatchLastReadMutation } from '@/lib/hooks/chat/usePatchLastReadMutat
 import { usePutRoomSettingsMutation } from '@/lib/hooks/chat/usePutRoomSettingsMutation';
 import { toast } from '@/lib/toast/store';
 import { uploadFile } from '@/lib/upload/uploadFile';
+import { formatDateKey, formatMessageTime, formatStickyDateLabel } from '@/lib/utils/chatDate';
 
 import type { ChatMessageResponse, SendChatMessagePayload } from '@/lib/api/chatMessages';
 import type { IMessage } from '@stomp/stompjs';
@@ -115,56 +116,6 @@ function resolveTitle(roomName: string | null, title: string | null) {
   }
 
   return '채팅방';
-}
-
-function parseKstDateTime(value: string): Date {
-  const normalized = value.includes(' ') ? value.replace(' ', 'T') : value;
-  const hasTimezone = /([zZ]|[+-]\d{2}:\d{2})$/.test(normalized);
-  if (hasTimezone) {
-    return new Date(normalized);
-  }
-
-  // Backend chat timestamps are currently serialized without timezone info but represent UTC.
-  return new Date(`${normalized}Z`);
-}
-
-function formatDateKey(value: string): string {
-  const date = parseKstDateTime(value);
-  if (Number.isNaN(date.getTime())) {
-    return value.slice(0, 10);
-  }
-
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-}
-
-function formatStickyDateLabel(value: string): string {
-  const date = parseKstDateTime(value);
-  if (Number.isNaN(date.getTime())) {
-    return value.slice(0, 10);
-  }
-
-  return date.toLocaleDateString('ko-KR', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-    weekday: 'short',
-  });
-}
-
-function formatMessageTime(value: string): string {
-  const date = parseKstDateTime(value);
-  if (Number.isNaN(date.getTime())) {
-    return '';
-  }
-
-  return date.toLocaleTimeString('ko-KR', {
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  });
 }
 
 function resolveMessageContent(message: ChatMessageResponse): string {

--- a/src/screens/chat/ChatRoomPage.tsx
+++ b/src/screens/chat/ChatRoomPage.tsx
@@ -15,8 +15,8 @@ import {
 import Image from 'next/image';
 import { useRouter, useSearchParams } from 'next/navigation';
 import {
+  startTransition,
   useCallback,
-  type ChangeEvent,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -29,25 +29,20 @@ import ConfirmModal from '@/components/common/ConfirmModal';
 import { useAppFrame } from '@/components/layout/AppFrameContext';
 import { useHeader } from '@/components/layout/HeaderContext';
 import {
-  ALLOWED_FILE_MIME_TYPES,
-  ALLOWED_IMAGE_MIME_TYPES,
   BOTTOM_CONFIRM_THRESHOLD,
   DELETE_LONG_PRESS_MS,
   LONG_MESSAGE_THRESHOLD,
-  MAX_ATTACHMENT_FILE_SIZE_BYTES,
-  MAX_IMAGE_ATTACHMENTS_PER_PICK,
   MESSAGE_PAGE_SIZE,
   MESSAGE_SEND_DESTINATION,
-  PDF_FILE_EXTENSION_REGEX,
   TOP_FETCH_THRESHOLD,
 } from '@/constants/chat';
-import { fetchChatMessages } from '@/lib/api/chatMessages';
 import { getUserIdFromAccessToken } from '@/lib/auth/token';
 import { applyRealtimeRoomMessage } from '@/lib/chat/realtimeMessageCache';
 import { applyRealtimeRoomNotification } from '@/lib/chat/realtimeRoomCache';
 import { clearRejoinedRoomUiOverride } from '@/lib/chat/rejoinedRoomUiCache';
 import { chatStompManager } from '@/lib/chat/stompManager';
 import { chatKeys } from '@/lib/hooks/chat/queryKeys';
+import { useAttachmentHandler } from '@/lib/hooks/chat/useAttachmentHandler';
 import { useChatMessagesInfiniteQuery } from '@/lib/hooks/chat/useChatMessagesInfiniteQuery';
 import { useChatRoomDetailQuery } from '@/lib/hooks/chat/useChatRoomDetailQuery';
 import { useChatSubscriptions } from '@/lib/hooks/chat/useChatSubscriptions';
@@ -56,7 +51,6 @@ import { useLeaveChatRoomMutation } from '@/lib/hooks/chat/useLeaveChatRoomMutat
 import { usePatchLastReadMutation } from '@/lib/hooks/chat/usePatchLastReadMutation';
 import { usePutRoomSettingsMutation } from '@/lib/hooks/chat/usePutRoomSettingsMutation';
 import { toast } from '@/lib/toast/store';
-import { uploadFile } from '@/lib/upload/uploadFile';
 import { formatDateKey, formatMessageTime, formatStickyDateLabel } from '@/lib/utils/chatDate';
 
 import type { ChatMessageResponse, SendChatMessagePayload } from '@/lib/api/chatMessages';
@@ -66,24 +60,6 @@ type ChatRoomPageProps = Readonly<{
   roomId: number | null;
   mode?: 'room' | 'settings';
 }>;
-
-function isPdfFile(file: File): boolean {
-  const mimeType = file.type.trim().toLowerCase();
-  if (mimeType && ALLOWED_FILE_MIME_TYPES.has(mimeType)) {
-    return true;
-  }
-
-  return PDF_FILE_EXTENSION_REGEX.test(file.name);
-}
-
-function resolveAttachmentMimeType(file: File, isImageAttachment: boolean): string {
-  if (isImageAttachment) {
-    return file.type || 'application/octet-stream';
-  }
-
-  // Some environments return empty/variant MIME for PDF. Normalize to application/pdf.
-  return isPdfFile(file) ? 'application/pdf' : file.type || 'application/octet-stream';
-}
 
 function resolveChatAssetUrl(s3KeyOrUrl: string | null): string | null {
   if (!s3KeyOrUrl) {
@@ -157,11 +133,6 @@ export default function ChatRoomPage({ roomId, mode = 'room' }: ChatRoomPageProp
   const [isLeavingRoom, setIsLeavingRoom] = useState(false);
   const [roomNameInput, setRoomNameInput] = useState('');
   const [isAlarmOnInput, setIsAlarmOnInput] = useState(true);
-  const [isAttachmentUploading, setIsAttachmentUploading] = useState(false);
-  const [isAttachmentPickerOpen, setIsAttachmentPickerOpen] = useState(false);
-  const [attachmentValidationMessage, setAttachmentValidationMessage] = useState<string | null>(
-    null,
-  );
   const [imagePreview, setImagePreview] = useState<{
     src: string;
     alt: string;
@@ -170,8 +141,6 @@ export default function ChatRoomPage({ roomId, mode = 'room' }: ChatRoomPageProp
   const activeRoomId = isLeavingRoom ? null : roomId;
   const { data, isLoading, isError, refetch } = useChatRoomDetailQuery(activeRoomId);
   const messageListRef = useRef<HTMLDivElement>(null);
-  const imageAttachmentInputRef = useRef<HTMLInputElement>(null);
-  const fileAttachmentInputRef = useRef<HTMLInputElement>(null);
   const unreadDividerRef = useRef<HTMLDivElement>(null);
   const deleteLongPressTimerRef = useRef<number | null>(null);
   const isMessageInputComposingRef = useRef(false);
@@ -182,7 +151,6 @@ export default function ChatRoomPage({ roomId, mode = 'room' }: ChatRoomPageProp
   const prevScrollHeightRef = useRef(0);
   const hasPatchedOnEntryRef = useRef(false);
   const lastPatchedMsgIdRef = useRef<number | null>(null);
-  const attachmentEchoFallbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const patchLastReadMutation = usePatchLastReadMutation(roomId ?? 0);
   const deleteMessageMutation = useDeleteMessageMutation(roomId ?? 0);
   const putRoomSettingsMutation = usePutRoomSettingsMutation(roomId ?? 0);
@@ -234,6 +202,20 @@ export default function ChatRoomPage({ roomId, mode = 'room' }: ChatRoomPageProp
   }, [currentUserId, messages, serverLastReadMsgId]);
 
   const isPrivateRoom = data?.type === 'PRIVATE';
+
+  const {
+    isAttachmentUploading,
+    isAttachmentPickerOpen,
+    setIsAttachmentPickerOpen,
+    attachmentValidationMessage,
+    setAttachmentValidationMessage,
+    imageAttachmentInputRef,
+    fileAttachmentInputRef,
+    handleAttachmentButtonClick,
+    handlePickImageAttachments,
+    handlePickFileAttachment,
+    handleAttachmentChange,
+  } = useAttachmentHandler({ roomId, queryClient });
 
   const toggleExpandedMessage = useCallback((messageId: number) => {
     setExpandedMessageIds((prev) => {
@@ -350,147 +332,6 @@ export default function ChatRoomPage({ roomId, mode = 'room' }: ChatRoomPageProp
       setMessageInput('');
     },
     [messageInput, roomId],
-  );
-
-  const handleAttachmentButtonClick = useCallback(() => {
-    if (isAttachmentUploading) {
-      return;
-    }
-
-    setIsAttachmentPickerOpen(true);
-  }, [isAttachmentUploading]);
-
-  const openAttachmentValidationModal = useCallback((message: string) => {
-    setIsAttachmentPickerOpen(false);
-    setAttachmentValidationMessage(message);
-  }, []);
-
-  const handlePickImageAttachments = useCallback(() => {
-    if (isAttachmentUploading) {
-      return;
-    }
-
-    setIsAttachmentPickerOpen(false);
-    imageAttachmentInputRef.current?.click();
-  }, [isAttachmentUploading]);
-
-  const handlePickFileAttachment = useCallback(() => {
-    if (isAttachmentUploading) {
-      return;
-    }
-
-    setIsAttachmentPickerOpen(false);
-    fileAttachmentInputRef.current?.click();
-  }, [isAttachmentUploading]);
-
-  const handleAttachmentChange = useCallback(
-    async (event: ChangeEvent<HTMLInputElement>) => {
-      const selectedFiles = Array.from(event.target.files ?? []);
-      event.target.value = '';
-
-      if (selectedFiles.length === 0 || roomId === null || isAttachmentUploading) {
-        return;
-      }
-
-      const imageFiles = selectedFiles.filter((file) => ALLOWED_IMAGE_MIME_TYPES.has(file.type));
-      const nonImageFiles = selectedFiles.filter(
-        (file) => !ALLOWED_IMAGE_MIME_TYPES.has(file.type),
-      );
-
-      if (imageFiles.length > 0 && nonImageFiles.length > 0) {
-        openAttachmentValidationModal('이미지와 파일은 동시에 첨부할 수 없습니다.');
-        return;
-      }
-
-      if (imageFiles.length > MAX_IMAGE_ATTACHMENTS_PER_PICK) {
-        openAttachmentValidationModal(
-          `이미지는 한 번에 최대 ${MAX_IMAGE_ATTACHMENTS_PER_PICK}장까지 첨부할 수 있습니다.`,
-        );
-        return;
-      }
-
-      if (nonImageFiles.length > 1) {
-        openAttachmentValidationModal('파일은 한 번에 1개만 첨부할 수 있습니다.');
-        return;
-      }
-
-      for (const file of selectedFiles) {
-        if (file.size > MAX_ATTACHMENT_FILE_SIZE_BYTES) {
-          openAttachmentValidationModal('파일 용량은 5MB 이하만 첨부할 수 있습니다.');
-          return;
-        }
-      }
-
-      if (nonImageFiles.length === 1 && !isPdfFile(nonImageFiles[0]!)) {
-        openAttachmentValidationModal('파일 첨부는 PDF 형식만 지원합니다.');
-        return;
-      }
-
-      setIsAttachmentUploading(true);
-
-      try {
-        for (const file of selectedFiles) {
-          const isImageAttachment = ALLOWED_IMAGE_MIME_TYPES.has(file.type);
-          const normalizedMimeType = resolveAttachmentMimeType(file, isImageAttachment);
-
-          const uploaded = await uploadFile({
-            file,
-            category: 'AI_CHAT_ATTACHMENT',
-            refType: 'CHATROOM',
-            refId: roomId,
-            mimeType: normalizedMimeType,
-          });
-
-          const payload: SendChatMessagePayload = isImageAttachment
-            ? {
-                roomId,
-                type: 'IMAGE',
-                content: null,
-                s3Key: uploaded.s3Key,
-              }
-            : {
-                roomId,
-                type: 'PDF',
-                content: uploaded.s3Key,
-                s3Key: uploaded.s3Key,
-              };
-
-          const published = chatStompManager.publishJson(MESSAGE_SEND_DESTINATION, payload);
-          if (!published) {
-            toast('첨부 메시지 전송에 실패했습니다. 잠시 후 다시 시도해 주세요.');
-            return;
-          }
-
-          // STOMP echo fallback: 백엔드가 FILE/IMAGE 메시지를 브로드캐스트하지 않는 경우
-          // 2초 후 REST API로 최신 메시지를 가져와 캐시에 병합합니다.
-          if (attachmentEchoFallbackTimerRef.current !== null) {
-            clearTimeout(attachmentEchoFallbackTimerRef.current);
-          }
-          const fallbackRoomId = roomId;
-          attachmentEchoFallbackTimerRef.current = setTimeout(() => {
-            attachmentEchoFallbackTimerRef.current = null;
-            void fetchChatMessages(fallbackRoomId, { size: MESSAGE_PAGE_SIZE }).then((result) => {
-              if (!result.ok || !result.json || !('data' in result.json) || !result.json.data) {
-                return;
-              }
-              for (const msg of result.json.data.messages) {
-                applyRealtimeRoomMessage(queryClient, {
-                  roomId: fallbackRoomId,
-                  size: MESSAGE_PAGE_SIZE,
-                  message: msg,
-                });
-              }
-            });
-          }, 2000);
-        }
-      } catch (error) {
-        const err = error as Error;
-        toast(err.message || '파일 업로드에 실패했습니다.');
-      } finally {
-        setIsAttachmentUploading(false);
-      }
-    },
-    [isAttachmentUploading, openAttachmentValidationModal, queryClient, roomId],
   );
 
   useChatSubscriptions({
@@ -663,9 +504,9 @@ export default function ChatRoomPage({ roomId, mode = 'room' }: ChatRoomPageProp
   ]);
 
   useEffect(() => {
-    if (attachmentEchoFallbackTimerRef.current !== null) {
-      clearTimeout(attachmentEchoFallbackTimerRef.current);
-      attachmentEchoFallbackTimerRef.current = null;
+    if (initialScrollResyncTimerRef.current !== null) {
+      window.clearTimeout(initialScrollResyncTimerRef.current);
+      initialScrollResyncTimerRef.current = null;
     }
     hasInitialScrollRef.current = false;
     hasNoUnreadInitialBottomResyncedRef.current = false;
@@ -673,8 +514,10 @@ export default function ChatRoomPage({ roomId, mode = 'room' }: ChatRoomPageProp
     prevScrollHeightRef.current = 0;
     hasPatchedOnEntryRef.current = false;
     lastPatchedMsgIdRef.current = null;
-    setIsLeavingRoom(false);
-    setMessageInput('');
+    startTransition(() => {
+      setIsLeavingRoom(false);
+      setMessageInput('');
+    });
   }, [roomId]);
 
   useEffect(() => {
@@ -689,8 +532,10 @@ export default function ChatRoomPage({ roomId, mode = 'room' }: ChatRoomPageProp
   }, [queryClient, roomId]);
 
   useEffect(() => {
-    setRoomNameInput(data?.roomName ?? '');
-    setIsAlarmOnInput(data?.isAlarmOn ?? true);
+    startTransition(() => {
+      setRoomNameInput(data?.roomName ?? '');
+      setIsAlarmOnInput(data?.isAlarmOn ?? true);
+    });
   }, [data?.isAlarmOn, data?.roomName, roomId]);
 
   useEffect(() => {

--- a/src/screens/chat/ChatRoomPage.tsx
+++ b/src/screens/chat/ChatRoomPage.tsx
@@ -18,7 +18,6 @@ import {
   startTransition,
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -34,7 +33,6 @@ import {
   LONG_MESSAGE_THRESHOLD,
   MESSAGE_PAGE_SIZE,
   MESSAGE_SEND_DESTINATION,
-  TOP_FETCH_THRESHOLD,
 } from '@/constants/chat';
 import { getUserIdFromAccessToken } from '@/lib/auth/token';
 import { applyRealtimeRoomMessage } from '@/lib/chat/realtimeMessageCache';
@@ -45,10 +43,10 @@ import { chatKeys } from '@/lib/hooks/chat/queryKeys';
 import { useAttachmentHandler } from '@/lib/hooks/chat/useAttachmentHandler';
 import { useChatMessagesInfiniteQuery } from '@/lib/hooks/chat/useChatMessagesInfiniteQuery';
 import { useChatRoomDetailQuery } from '@/lib/hooks/chat/useChatRoomDetailQuery';
+import { useChatScroll } from '@/lib/hooks/chat/useChatScroll';
 import { useChatSubscriptions } from '@/lib/hooks/chat/useChatSubscriptions';
 import { useDeleteMessageMutation } from '@/lib/hooks/chat/useDeleteMessageMutation';
 import { useLeaveChatRoomMutation } from '@/lib/hooks/chat/useLeaveChatRoomMutation';
-import { usePatchLastReadMutation } from '@/lib/hooks/chat/usePatchLastReadMutation';
 import { usePutRoomSettingsMutation } from '@/lib/hooks/chat/usePutRoomSettingsMutation';
 import { toast } from '@/lib/toast/store';
 import { formatDateKey, formatMessageTime, formatStickyDateLabel } from '@/lib/utils/chatDate';
@@ -140,18 +138,8 @@ export default function ChatRoomPage({ roomId, mode = 'room' }: ChatRoomPageProp
   const isSettingsPage = mode === 'settings';
   const activeRoomId = isLeavingRoom ? null : roomId;
   const { data, isLoading, isError, refetch } = useChatRoomDetailQuery(activeRoomId);
-  const messageListRef = useRef<HTMLDivElement>(null);
-  const unreadDividerRef = useRef<HTMLDivElement>(null);
   const deleteLongPressTimerRef = useRef<number | null>(null);
   const isMessageInputComposingRef = useRef(false);
-  const initialScrollResyncTimerRef = useRef<number | null>(null);
-  const hasInitialScrollRef = useRef(false);
-  const hasNoUnreadInitialBottomResyncedRef = useRef(false);
-  const isLoadingOlderRef = useRef(false);
-  const prevScrollHeightRef = useRef(0);
-  const hasPatchedOnEntryRef = useRef(false);
-  const lastPatchedMsgIdRef = useRef<number | null>(null);
-  const patchLastReadMutation = usePatchLastReadMutation(roomId ?? 0);
   const deleteMessageMutation = useDeleteMessageMutation(roomId ?? 0);
   const putRoomSettingsMutation = usePutRoomSettingsMutation(roomId ?? 0);
   const leaveChatRoomMutation = useLeaveChatRoomMutation(roomId ?? 0);
@@ -203,6 +191,20 @@ export default function ChatRoomPage({ roomId, mode = 'room' }: ChatRoomPageProp
 
   const isPrivateRoom = data?.type === 'PRIVATE';
 
+  const { messageListRef, unreadDividerRef, handleMessageScroll, patchLastReadOnce } =
+    useChatScroll({
+      roomId,
+      messages,
+      unreadStartIndex,
+      serverLastReadMsgId,
+      latestMessageId,
+      isMessagesLoading,
+      isMessagesError,
+      fetchNextPage,
+      hasNextPage,
+      isFetchingNextPage,
+    });
+
   const {
     isAttachmentUploading,
     isAttachmentPickerOpen,
@@ -228,29 +230,6 @@ export default function ChatRoomPage({ roomId, mode = 'room' }: ChatRoomPageProp
       return next;
     });
   }, []);
-
-  const patchLastReadOnce = useCallback(
-    (targetMessageId: number) => {
-      if (roomId === null) {
-        return;
-      }
-
-      if (targetMessageId <= 0 || patchLastReadMutation.isPending) {
-        return;
-      }
-
-      if (lastPatchedMsgIdRef.current !== null && targetMessageId <= lastPatchedMsgIdRef.current) {
-        return;
-      }
-
-      patchLastReadMutation.mutate(targetMessageId, {
-        onSuccess: () => {
-          lastPatchedMsgIdRef.current = targetMessageId;
-        },
-      });
-    },
-    [patchLastReadMutation, roomId],
-  );
 
   const handleRealtimeRoomMessage = useCallback(
     (frame: IMessage) => {
@@ -300,7 +279,7 @@ export default function ChatRoomPage({ roomId, mode = 'room' }: ChatRoomPageProp
         });
       }
     },
-    [currentUserId, patchLastReadOnce, queryClient, roomId],
+    [currentUserId, messageListRef, patchLastReadOnce, queryClient, roomId],
   );
 
   const handleSendMessage = useCallback(
@@ -504,16 +483,6 @@ export default function ChatRoomPage({ roomId, mode = 'room' }: ChatRoomPageProp
   ]);
 
   useEffect(() => {
-    if (initialScrollResyncTimerRef.current !== null) {
-      window.clearTimeout(initialScrollResyncTimerRef.current);
-      initialScrollResyncTimerRef.current = null;
-    }
-    hasInitialScrollRef.current = false;
-    hasNoUnreadInitialBottomResyncedRef.current = false;
-    isLoadingOlderRef.current = false;
-    prevScrollHeightRef.current = 0;
-    hasPatchedOnEntryRef.current = false;
-    lastPatchedMsgIdRef.current = null;
     startTransition(() => {
       setIsLeavingRoom(false);
       setMessageInput('');
@@ -541,136 +510,8 @@ export default function ChatRoomPage({ roomId, mode = 'room' }: ChatRoomPageProp
   useEffect(() => {
     return () => {
       clearDeleteLongPressTimer();
-      if (initialScrollResyncTimerRef.current !== null) {
-        window.clearTimeout(initialScrollResyncTimerRef.current);
-        initialScrollResyncTimerRef.current = null;
-      }
     };
   }, [clearDeleteLongPressTimer]);
-
-  useEffect(() => {
-    if (serverLastReadMsgId === null) {
-      return;
-    }
-
-    if (lastPatchedMsgIdRef.current === null) {
-      lastPatchedMsgIdRef.current = serverLastReadMsgId;
-    }
-  }, [serverLastReadMsgId]);
-
-  useLayoutEffect(() => {
-    const container = messageListRef.current;
-    if (!container || messages.length === 0) {
-      return;
-    }
-
-    if (!hasInitialScrollRef.current) {
-      if (unreadStartIndex >= 0 && unreadDividerRef.current) {
-        const dividerTop = unreadDividerRef.current.offsetTop;
-        container.scrollTop = Math.max(0, dividerTop - container.clientHeight * 0.35);
-      } else {
-        container.scrollTop = container.scrollHeight;
-        requestAnimationFrame(() => {
-          const currentContainer = messageListRef.current;
-          if (!currentContainer) {
-            return;
-          }
-          currentContainer.scrollTop = currentContainer.scrollHeight;
-        });
-        if (initialScrollResyncTimerRef.current !== null) {
-          window.clearTimeout(initialScrollResyncTimerRef.current);
-        }
-        initialScrollResyncTimerRef.current = window.setTimeout(() => {
-          const currentContainer = messageListRef.current;
-          if (!currentContainer) {
-            return;
-          }
-          currentContainer.scrollTop = currentContainer.scrollHeight;
-          initialScrollResyncTimerRef.current = null;
-        }, 300);
-      }
-      hasInitialScrollRef.current = true;
-      return;
-    }
-
-    if (isLoadingOlderRef.current) {
-      const newScrollHeight = container.scrollHeight;
-      const scrollDiff = newScrollHeight - prevScrollHeightRef.current;
-      container.scrollTop += scrollDiff;
-      isLoadingOlderRef.current = false;
-    }
-  }, [messages, unreadStartIndex]);
-
-  useEffect(() => {
-    if (!hasInitialScrollRef.current) {
-      return;
-    }
-
-    if (hasNoUnreadInitialBottomResyncedRef.current) {
-      return;
-    }
-
-    if (messages.length === 0 || unreadStartIndex >= 0) {
-      return;
-    }
-
-    const container = messageListRef.current;
-    if (!container) {
-      return;
-    }
-
-    hasNoUnreadInitialBottomResyncedRef.current = true;
-
-    const timerId = window.setTimeout(() => {
-      const currentContainer = messageListRef.current;
-      if (!currentContainer) {
-        return;
-      }
-      currentContainer.scrollTop = currentContainer.scrollHeight;
-    }, 150);
-
-    return () => {
-      window.clearTimeout(timerId);
-    };
-  }, [messages.length, unreadStartIndex]);
-
-  useEffect(() => {
-    if (roomId === null || isMessagesLoading || isMessagesError || latestMessageId === null) {
-      return;
-    }
-
-    if (hasPatchedOnEntryRef.current) {
-      return;
-    }
-
-    hasPatchedOnEntryRef.current = true;
-    patchLastReadOnce(latestMessageId);
-  }, [isMessagesError, isMessagesLoading, latestMessageId, patchLastReadOnce, roomId]);
-
-  const handleMessageScroll = useCallback(() => {
-    const container = messageListRef.current;
-    if (!container) {
-      return;
-    }
-
-    const distanceFromBottom =
-      container.scrollHeight - (container.scrollTop + container.clientHeight);
-    if (distanceFromBottom <= BOTTOM_CONFIRM_THRESHOLD && latestMessageId !== null) {
-      patchLastReadOnce(latestMessageId);
-    }
-
-    if (!hasNextPage || isFetchingNextPage) {
-      return;
-    }
-
-    if (container.scrollTop > TOP_FETCH_THRESHOLD) {
-      return;
-    }
-
-    prevScrollHeightRef.current = container.scrollHeight;
-    isLoadingOlderRef.current = true;
-    void fetchNextPage();
-  }, [fetchNextPage, hasNextPage, isFetchingNextPage, latestMessageId, patchLastReadOnce]);
 
   if (roomId === null) {
     return (

--- a/src/screens/llm/LlmChatPage.tsx
+++ b/src/screens/llm/LlmChatPage.tsx
@@ -23,6 +23,8 @@ type Props = {
 };
 
 const DEFAULT_MODEL: LlmModel = 'GEMINI';
+const BLOCK_MSG_STREAMING = '답변 생성 중에는 이동할 수 없습니다.';
+const BLOCK_MSG_INTERVIEW = '면접 진행 중에는 이동할 수 없습니다.';
 function parseModel(value: string | null | undefined): LlmModel {
   if (value === 'GEMINI' || value === 'VLLM') {
     return value;
@@ -124,11 +126,9 @@ export default function LlmChatPage({ roomId: _roomId, numericRoomId, initialMod
       session.uiState === 'ending';
     const shouldBlock = Boolean(streamingAiId) || isInterviewInProgress;
 
-    setBlockMessage(
-      streamingAiId
-        ? '답변 생성 중에는 이동할 수 없습니다.'
-        : '면접 진행 중에는 이동할 수 없습니다.',
-    );
+    if (shouldBlock) {
+      setBlockMessage(streamingAiId ? BLOCK_MSG_STREAMING : BLOCK_MSG_INTERVIEW);
+    }
     setBlocked(shouldBlock);
     return () => setBlocked(false);
   }, [session.uiState, setBlocked, setBlockMessage, streamingAiId]);

--- a/src/screens/llm/LlmChatPage.tsx
+++ b/src/screens/llm/LlmChatPage.tsx
@@ -6,6 +6,7 @@ import { useAppFrame } from '@/components/layout/AppFrameContext';
 import { useNavigationGuard } from '@/components/layout/NavigationGuardContext';
 import LlmComposer from '@/components/llm/chat/LlmComposer';
 import LlmMessageList from '@/components/llm/chat/LlmMessageList';
+import { BLOCK_MSG_INTERVIEW, BLOCK_MSG_STREAMING, DEFAULT_LLM_MODEL } from '@/constants/llm';
 import { useInterviewEvaluation } from '@/lib/hooks/llm/useInterviewEvaluation';
 import { useInterviewSession } from '@/lib/hooks/llm/useInterviewSession';
 import { useLlmStreaming } from '@/lib/hooks/llm/useLlmStreaming';
@@ -22,14 +23,11 @@ type Props = {
   initialModel?: string | null;
 };
 
-const DEFAULT_MODEL: LlmModel = 'GEMINI';
-const BLOCK_MSG_STREAMING = '답변 생성 중에는 이동할 수 없습니다.';
-const BLOCK_MSG_INTERVIEW = '면접 진행 중에는 이동할 수 없습니다.';
 function parseModel(value: string | null | undefined): LlmModel {
   if (value === 'GEMINI' || value === 'VLLM') {
     return value;
   }
-  return DEFAULT_MODEL;
+  return DEFAULT_LLM_MODEL;
 }
 
 export default function LlmChatPage({ roomId: _roomId, numericRoomId, initialModel }: Props) {


### PR DESCRIPTION
## 📌 작업한 내용

코드 가독성과 유지보수성 개선을 위한 리팩토링 (총 6커밋)

---

## 1) 매직 넘버 상수화 — `constants/` 도메인별 분리

흩어진 숫자/문자열 리터럴을 도메인별 상수 파일로 이동해, 변경 시 **단일 위치만 수정**하도록 개선했습니다.

### 추가/확장된 상수 파일

| 파일 | 내용 |
|---|---|
| `src/constants/chat.ts` *(신규)* | `MESSAGE_PAGE_SIZE`, `BOTTOM_CONFIRM_THRESHOLD`, `TOP_FETCH_THRESHOLD`, `DELETE_LONG_PRESS_MS`, `LONG_MESSAGE_THRESHOLD` 등 **15개** |
| `src/constants/board.ts` *(기존 확장)* | `BOARD_PAGE_SIZE`, `PULL_MAX`, `PULL_THRESHOLD`, `SEARCH_PAGE_SIZE` 등 **8개** |
| `src/constants/llm.ts` *(신규)* | `DEFAULT_LLM_MODEL`, `BLOCK_MSG_STREAMING`, `BLOCK_MSG_INTERVIEW` |

### 적용 파일

- `ChatRoomPage.tsx`
- `ChatPlaceholderPage.tsx`
- `ChatCreatePage.tsx`
- `BoardListPage.tsx`
- `BoardSearchPage.tsx`
- `LlmChatPage.tsx`

---

## 2) `ChatRoomPage.tsx` 관심사 분리 — 3개 훅/유틸 추출

### 2-1. `src/lib/utils/chatDate.ts` *(신규)*
- `parseKstDateTime`, `formatDateKey`, `formatStickyDateLabel`, `formatMessageTime` 이전
- **사이드이펙트 없는 순수 함수**로 분리하여 재사용성 및 테스트 가능성 향상

### 2-2. `src/lib/hooks/chat/useAttachmentHandler.ts` *(신규)*
- 첨부파일 **업로드/검증/모달** 관련 상태·ref·콜백을 전부 캡슐화
- 포함 기능
  - `isPdfFile`, `resolveAttachmentMimeType`
  - `isAttachmentUploading`, `isAttachmentPickerOpen`
  - `attachmentValidationMessage`
  - STOMP echo fallback 타이머
- `roomId` 변경 시 타이머 자동 정리

### 2-3. `src/lib/hooks/chat/useChatScroll.ts` *(신규)*
- 스크롤 고정, 초기 스크롤 동기화, 이전 메시지 로딩 시 높이 보정, 읽음 패치 로직 캡슐화
- 포함 범위
  - `patchLastReadMutation`
  - 스크롤 관련 ref **9개**
  - `patchLastReadOnce`, `handleMessageScroll`
  - 관련 effect **5개**
- 출력(API)
  - `messageListRef`
  - `unreadDividerRef`
  - `handleMessageScroll`
  - `patchLastReadOnce`

### 결과
- `ChatRoomPage.tsx` **1593줄 → 1230줄 (-363줄)**

## 🔍 참고 사항

<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

Ref #175 

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
- [ ] (채팅) `/api/chatrooms` pagination에서 서버 cursor 재사용 원칙 준수 확인
