### PR TITLE
refactor: 첨부 상수, 날짜 유틸, 중복 함수 응집도 개선

### DIFF
--- a/src/constants/attachment.ts
+++ b/src/constants/attachment.ts
@@ -30,3 +30,15 @@ export const CHAT_ATTACHMENT_CONSTRAINTS: AttachmentConstraints = {
   imageMimeTypes: IMAGE_MIME_TYPES,
   fileMimeTypes: FILE_MIME_TYPES,
 };
+
+export const BOARD_IMAGE_MIME_TYPES = ['image/jpeg', 'image/jpg', 'image/png'] as const;
+export const BOARD_FILE_MIME_TYPES = ['application/pdf'] as const;
+export const BOARD_FILE_MAX_SIZE_MB = 10;
+
+export const BOARD_ATTACHMENT_CONSTRAINTS: AttachmentConstraints = {
+  maxImages: 10,
+  maxFiles: 5,
+  maxSizeMB: BOARD_FILE_MAX_SIZE_MB,
+  imageMimeTypes: BOARD_IMAGE_MIME_TYPES,
+  fileMimeTypes: BOARD_FILE_MIME_TYPES,
+};

--- a/src/constants/boardCreate.ts
+++ b/src/constants/boardCreate.ts
@@ -3,15 +3,3 @@ export const BOARD_TITLE_MAX_LENGTH = 50;
 export const BOARD_CONTENT_MIN_LENGTH = 10;
 export const BOARD_CONTENT_MAX_LENGTH = 5000;
 export const BOARD_TAG_MAX = 4;
-
-export const BOARD_FILE_MAX_SIZE_MB = 10;
-export const BOARD_IMAGE_MIME_TYPES = ['image/jpeg', 'image/jpg', 'image/png'] as const;
-export const BOARD_FILE_MIME_TYPES = ['application/pdf'] as const;
-
-export const BOARD_ATTACHMENT_CONSTRAINTS = {
-  maxImages: 10,
-  maxFiles: 5,
-  maxSizeMB: BOARD_FILE_MAX_SIZE_MB,
-  imageMimeTypes: BOARD_IMAGE_MIME_TYPES,
-  fileMimeTypes: BOARD_FILE_MIME_TYPES,
-} as const;

--- a/src/lib/utils/chatDate.ts
+++ b/src/lib/utils/chatDate.ts
@@ -1,16 +1,7 @@
-export function parseKstDateTime(value: string): Date {
-  const normalized = value.includes(' ') ? value.replace(' ', 'T') : value;
-  const hasTimezone = /([zZ]|[+-]\d{2}:\d{2})$/.test(normalized);
-  if (hasTimezone) {
-    return new Date(normalized);
-  }
-
-  // Backend chat timestamps are currently serialized without timezone info but represent UTC.
-  return new Date(`${normalized}Z`);
-}
+import { parseServerDateTime } from '@/lib/utils/datetime';
 
 export function formatDateKey(value: string): string {
-  const date = parseKstDateTime(value);
+  const date = parseServerDateTime(value);
   if (Number.isNaN(date.getTime())) {
     return value.slice(0, 10);
   }
@@ -22,7 +13,7 @@ export function formatDateKey(value: string): string {
 }
 
 export function formatStickyDateLabel(value: string): string {
-  const date = parseKstDateTime(value);
+  const date = parseServerDateTime(value);
   if (Number.isNaN(date.getTime())) {
     return value.slice(0, 10);
   }
@@ -36,7 +27,7 @@ export function formatStickyDateLabel(value: string): string {
 }
 
 export function formatMessageTime(value: string): string {
-  const date = parseKstDateTime(value);
+  const date = parseServerDateTime(value);
   if (Number.isNaN(date.getTime())) {
     return '';
   }

--- a/src/lib/utils/datetime.ts
+++ b/src/lib/utils/datetime.ts
@@ -4,6 +4,25 @@ const TIME_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
   hour12: true,
 };
 
+export function parseServerDateTime(value: string): Date {
+  const normalized = value.includes(' ') ? value.replace(' ', 'T') : value;
+  const hasTimezone = /([zZ]|[+-]\d{2}:\d{2})$/.test(normalized);
+  if (hasTimezone) {
+    return new Date(normalized);
+  }
+
+  // Server timestamps are serialized without timezone info but represent UTC.
+  return new Date(`${normalized}Z`);
+}
+
+export function formatTime(date: Date): string {
+  return date.toLocaleTimeString('ko-KR', TIME_FORMAT_OPTIONS);
+}
+
+export function formatMessageTime(isoString: string): string {
+  return formatTime(parseServerDateTime(isoString));
+}
+
 export function nowTimeLabel(now = new Date()): string {
-  return now.toLocaleTimeString('ko-KR', TIME_FORMAT_OPTIONS);
+  return formatTime(now);
 }

--- a/src/lib/utils/llm.ts
+++ b/src/lib/utils/llm.ts
@@ -1,4 +1,5 @@
 import { getRoomStorageMode } from '@/lib/storage/aiChatroomStorage';
+import { formatMessageTime, parseServerDateTime } from '@/lib/utils/datetime';
 
 import type { LlmRoom } from '@/components/llm/rooms/types';
 import type { AiChatRoom, ChatMessage } from '@/types/llm';
@@ -23,14 +24,7 @@ export type UIMessage = {
 };
 
 export function parseLlmDateTime(value: string): Date {
-  const normalized = value.includes(' ') ? value.replace(' ', 'T') : value;
-  const hasTimezone = /([zZ]|[+-]\d{2}:\d{2})$/.test(normalized);
-  if (hasTimezone) {
-    return new Date(normalized);
-  }
-
-  // AI chatbot timestamps are serialized without timezone info but represent UTC.
-  return new Date(`${normalized}Z`);
+  return parseServerDateTime(value);
 }
 
 export function formatUpdatedAt(isoString: string): string {
@@ -96,13 +90,4 @@ export function toUIMessage(msg: ChatMessage): UIMessage {
     interviewId: msg.interviewId,
     isInterviewEvaluation,
   };
-}
-
-function formatMessageTime(isoString: string): string {
-  const date = parseLlmDateTime(isoString);
-  return date.toLocaleTimeString('ko-KR', {
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true,
-  });
 }

--- a/src/lib/validators/attachment.ts
+++ b/src/lib/validators/attachment.ts
@@ -17,11 +17,7 @@ export type ValidateFilesResult = {
   errors: AttachmentError[];
 };
 
-function isImageMime(mimeType: string, allowedMimes: readonly string[]): boolean {
-  return allowedMimes.includes(mimeType);
-}
-
-function isFileMime(mimeType: string, allowedMimes: readonly string[]): boolean {
+function isMimeTypeAllowed(mimeType: string, allowedMimes: readonly string[]): boolean {
   return allowedMimes.includes(mimeType);
 }
 
@@ -40,8 +36,8 @@ export function validateFiles(
   let fileCount = existingFiles;
 
   for (const file of files) {
-    const isImage = isImageMime(file.type, constraints.imageMimeTypes);
-    const isFile = isFileMime(file.type, constraints.fileMimeTypes);
+    const isImage = isMimeTypeAllowed(file.type, constraints.imageMimeTypes);
+    const isFile = isMimeTypeAllowed(file.type, constraints.fileMimeTypes);
 
     if (!isImage && !isFile) {
       errors.push({

--- a/src/screens/board/BoardCreatePage.tsx
+++ b/src/screens/board/BoardCreatePage.tsx
@@ -17,11 +17,10 @@ import { useHeader } from '@/components/layout/HeaderContext';
 import { useNavigationGuard } from '@/components/layout/NavigationGuardContext';
 import {
   BOARD_ATTACHMENT_CONSTRAINTS,
-  BOARD_CONTENT_MAX_LENGTH,
   BOARD_FILE_MIME_TYPES,
   BOARD_IMAGE_MIME_TYPES,
-  BOARD_TITLE_MAX_LENGTH,
-} from '@/constants/boardCreate';
+} from '@/constants/attachment';
+import { BOARD_CONTENT_MAX_LENGTH, BOARD_TITLE_MAX_LENGTH } from '@/constants/boardCreate';
 import { createBoardPost } from '@/lib/api/boards';
 import { ApiError } from '@/lib/errors/ApiError';
 import { useBoardAttachments } from '@/lib/hooks/boards/useBoardAttachments';

--- a/src/screens/board/BoardEditPage.tsx
+++ b/src/screens/board/BoardEditPage.tsx
@@ -17,11 +17,10 @@ import { useHeader } from '@/components/layout/HeaderContext';
 import { useNavigationGuard } from '@/components/layout/NavigationGuardContext';
 import {
   BOARD_ATTACHMENT_CONSTRAINTS,
-  BOARD_CONTENT_MAX_LENGTH,
   BOARD_FILE_MIME_TYPES,
   BOARD_IMAGE_MIME_TYPES,
-  BOARD_TITLE_MAX_LENGTH,
-} from '@/constants/boardCreate';
+} from '@/constants/attachment';
+import { BOARD_CONTENT_MAX_LENGTH, BOARD_TITLE_MAX_LENGTH } from '@/constants/boardCreate';
 import { updateBoardPost } from '@/lib/api/boards';
 import { ApiError } from '@/lib/errors/ApiError';
 import { boardsKeys } from '@/lib/hooks/boards/queryKeys';

--- a/src/screens/chat/ChatPlaceholderPage.tsx
+++ b/src/screens/chat/ChatPlaceholderPage.tsx
@@ -13,26 +13,17 @@ import { ROOM_NAME_MAX_LENGTH, ROOM_PAGE_SIZE } from '@/constants/chat';
 import { fetchChatRooms } from '@/lib/api/chatRooms';
 import { chatKeys } from '@/lib/hooks/chat/queryKeys';
 import { useChatRoomsInfiniteQuery } from '@/lib/hooks/chat/useChatRoomsInfiniteQuery';
+import { parseServerDateTime } from '@/lib/utils/datetime';
 
 import type { ChatRoomListResponse } from '@/lib/api/chatRooms';
 import type { RejoinedRoomUiOverrideMap } from '@/lib/chat/rejoinedRoomUiCache';
-
-function parseKstDateTime(value: string): Date {
-  const normalized = value.includes(' ') ? value.replace(' ', 'T') : value;
-  const hasTimezone = /([zZ]|[+-]\d{2}:\d{2})$/.test(normalized);
-  if (hasTimezone) {
-    return new Date(normalized);
-  }
-  // Backend chat timestamps are currently serialized without timezone info but represent UTC.
-  return new Date(`${normalized}Z`);
-}
 
 function formatRoomTime(isoString: string | null): string {
   if (!isoString) {
     return '';
   }
 
-  const date = parseKstDateTime(isoString);
+  const date = parseServerDateTime(isoString);
   if (Number.isNaN(date.getTime())) {
     return '';
   }
@@ -85,7 +76,7 @@ function resolveTimestamp(value: string | null): number | null {
     return null;
   }
 
-  const parsed = parseKstDateTime(value);
+  const parsed = parseServerDateTime(value);
   if (Number.isNaN(parsed.getTime())) {
     return null;
   }

--- a/src/screens/llm/LlmRoomsPage.tsx
+++ b/src/screens/llm/LlmRoomsPage.tsx
@@ -12,7 +12,8 @@ import { useDeleteRoomMutation } from '@/lib/hooks/llm/useDeleteRoomMutation';
 import { useRoomsInfiniteQuery } from '@/lib/hooks/llm/useRoomsInfiniteQuery';
 import { useAnalysisTaskStore } from '@/lib/llm/analysisTaskStore';
 import { toast } from '@/lib/toast/store';
-import { formatUpdatedAt, mapAiChatRoomToLlmRoom, parseLlmDateTime } from '@/lib/utils/llm';
+import { parseServerDateTime } from '@/lib/utils/datetime';
+import { formatUpdatedAt, mapAiChatRoomToLlmRoom } from '@/lib/utils/llm';
 
 export default function LlmRoomsPage() {
   const router = useRouter();
@@ -81,7 +82,9 @@ export default function LlmRoomsPage() {
       .flatMap((page) => (page ? page.rooms : []))
       .sort((a, b) => {
         // Backend timestamps may be timezone-less LocalDateTime strings that represent UTC.
-        return parseLlmDateTime(b.updatedAt).getTime() - parseLlmDateTime(a.updatedAt).getTime();
+        return (
+          parseServerDateTime(b.updatedAt).getTime() - parseServerDateTime(a.updatedAt).getTime()
+        );
       })
       .map(mapAiChatRoomToLlmRoom) ?? [];
 


### PR DESCRIPTION
## 📌 작업한 내용

코드 응집도 향상을 위한 리팩토링 3종                                               
                                                                                     
  Board 첨부 제약 상수 통합                                                
  - `BOARD_ATTACHMENT_CONSTRAINTS`, `BOARD_IMAGE_MIME_TYPES`,                        
  `BOARD_FILE_MIME_TYPES`, `BOARD_FILE_MAX_SIZE_MB`를 `constants/boardCreate.ts` →   
  `constants/attachment.ts`로 이동                                                   
  - LLM / CHAT / BOARD 세 도메인의 첨부 제약을 `attachment.ts` 한 파일에서 관리
  - `BOARD_ATTACHMENT_CONSTRAINTS`에 `AttachmentConstraints` 타입 명시 적용
  - `BoardCreatePage`, `BoardEditPage` import 경로 수정

 날짜/시간 파서·포맷터 통합
  - `parseLlmDateTime`(llm.ts) / `parseKstDateTime`(chatDate.ts) / 로컬
  `parseKstDateTime`(ChatPlaceholderPage.tsx) — 완전히 동일한 파서 로직 3곳 →
  `parseServerDateTime`으로 통합
  - `formatTime(date)` 추가 — `toLocaleTimeString` 옵션 단일화
  - `formatMessageTime(isoString)` 추가 — `parseServerDateTime` + `formatTime` 조합
  - `nowTimeLabel()` → `formatTime` 위임으로 단순화
  - `parseLlmDateTime` export는 thin wrapper로 하위 호환 유지

  중복 함수 통합
  - `isImageMime` / `isFileMime` — 완전히 동일한 구현 2개 → `isMimeTypeAllowed`
  하나로 통합

## 🔍 참고 사항

<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
- [ ] (채팅) `/api/chatrooms` pagination에서 서버 cursor 재사용 원칙 준수 확인
