### PR TITLE
[#186] refactor: Board 페이지 상태·로직 Custom Hook 분리

### DIFF
--- a/src/lib/hooks/boards/useBoardForm.ts
+++ b/src/lib/hooks/boards/useBoardForm.ts
@@ -1,0 +1,30 @@
+import { useMemo, useState } from 'react';
+
+import { validateBoardCreateContent, validateBoardCreateTitle } from '@/lib/validators/boardCreate';
+
+import type { BoardTag } from '@/types/board';
+
+export function useBoardForm() {
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [isPreview, setIsPreview] = useState(false);
+  const [tags, setTags] = useState<BoardTag[]>([]);
+
+  const titleError = useMemo(() => validateBoardCreateTitle(title), [title]);
+  const contentError = useMemo(() => validateBoardCreateContent(content), [content]);
+  const isSubmitEnabled = useMemo(() => !titleError && !contentError, [titleError, contentError]);
+
+  return {
+    title,
+    setTitle,
+    content,
+    setContent,
+    isPreview,
+    setIsPreview,
+    tags,
+    setTags,
+    titleError,
+    contentError,
+    isSubmitEnabled,
+  };
+}

--- a/src/lib/hooks/boards/useBoardMiniProfile.ts
+++ b/src/lib/hooks/boards/useBoardMiniProfile.ts
@@ -1,0 +1,104 @@
+import { useQuery } from '@tanstack/react-query';
+import { useMemo, useState } from 'react';
+
+import { fetchUserProfile } from '@/lib/api/users';
+import { ApiError } from '@/lib/errors/ApiError';
+import { userKeys } from '@/lib/hooks/users/queryKeys';
+import { useFollowUserMutation } from '@/lib/hooks/users/useFollowUserMutation';
+import { useUnfollowUserMutation } from '@/lib/hooks/users/useUnfollowUserMutation';
+import { toast } from '@/lib/toast/store';
+
+import type { BoardPostSummary } from '@/types/board';
+
+type Params = {
+  rawPosts: BoardPostSummary[];
+  currentUserId: number | null;
+};
+
+export function useBoardMiniProfile({ rawPosts, currentUserId }: Params) {
+  const [isMiniProfileOpen, setIsMiniProfileOpen] = useState(false);
+  const [selectedAuthorId, setSelectedAuthorId] = useState<number | null>(null);
+  const [followStateOverrides, setFollowStateOverrides] = useState<Record<number, boolean>>({});
+
+  const followMutation = useFollowUserMutation();
+  const unfollowMutation = useUnfollowUserMutation();
+
+  const selectedAuthor = useMemo(
+    () => rawPosts.find((post) => post.author.userId === selectedAuthorId)?.author ?? null,
+    [rawPosts, selectedAuthorId],
+  );
+
+  const { data: selectedAuthorProfile, refetch: refetchSelectedAuthorProfile } = useQuery({
+    queryKey: userKeys.profile(selectedAuthorId ?? -1),
+    queryFn: async () => {
+      const result = await fetchUserProfile(selectedAuthorId!);
+
+      if (!result.ok || !result.json) {
+        throw new Error('Failed to fetch user profile');
+      }
+
+      if ('data' in result.json && result.json.data) {
+        return result.json.data;
+      }
+
+      throw new Error('Invalid response format');
+    },
+    enabled: selectedAuthorId !== null,
+  });
+
+  const modalUser = selectedAuthor
+    ? {
+        userId: selectedAuthor.userId,
+        nickname: selectedAuthorProfile?.user.nickname ?? selectedAuthor.nickname,
+        profileImageUrl:
+          selectedAuthorProfile?.profileImage?.url ?? selectedAuthor.profileImageUrl ?? null,
+        interests: selectedAuthorProfile?.interests ?? selectedAuthor.interests ?? [],
+      }
+    : null;
+
+  const modalUserId = modalUser?.userId ?? null;
+  const isMine = Boolean(
+    modalUserId !== null && currentUserId !== null && modalUserId === currentUserId,
+  );
+  const profileIsFollowing = selectedAuthorProfile?.isFollowing ?? false;
+  const isFollowing =
+    modalUserId !== null && followStateOverrides[modalUserId] !== undefined
+      ? followStateOverrides[modalUserId]
+      : profileIsFollowing;
+  const isFollowPending = followMutation.isPending || unfollowMutation.isPending;
+
+  const handleAuthorClick = (userId: number) => {
+    setSelectedAuthorId(userId);
+    setIsMiniProfileOpen(true);
+  };
+
+  const handleToggleFollow = async () => {
+    if (modalUserId === null || isMine || isFollowPending) return;
+
+    try {
+      if (isFollowing) {
+        await unfollowMutation.mutateAsync(modalUserId);
+        setFollowStateOverrides((prev) => ({ ...prev, [modalUserId]: false }));
+      } else {
+        await followMutation.mutateAsync(modalUserId);
+        setFollowStateOverrides((prev) => ({ ...prev, [modalUserId]: true }));
+      }
+      void refetchSelectedAuthorProfile();
+    } catch (error) {
+      const err = ApiError.fromUnknown(error);
+      toast(err.serverMessage ?? '팔로우 처리에 실패했습니다.');
+    }
+  };
+
+  return {
+    isMiniProfileOpen,
+    setIsMiniProfileOpen,
+    modalUser,
+    modalUserId,
+    isMine,
+    isFollowing,
+    isFollowPending,
+    handleAuthorClick,
+    handleToggleFollow,
+  };
+}

--- a/src/lib/hooks/boards/useFilteredPosts.ts
+++ b/src/lib/hooks/boards/useFilteredPosts.ts
@@ -1,0 +1,47 @@
+import { useMemo } from 'react';
+
+import { POPULAR_MIN_LIKES } from '@/constants/board';
+import { parseBoardDateTime } from '@/lib/utils/board';
+
+import type { BoardPostSummary, BoardSort, BoardTag } from '@/types/board';
+
+type Options = {
+  sort: BoardSort;
+  selectedTags: BoardTag[];
+  followingAuthorIds: number[] | undefined;
+};
+
+export function useFilteredPosts(
+  rawPosts: BoardPostSummary[],
+  options: Options,
+): BoardPostSummary[] {
+  const { sort, selectedTags, followingAuthorIds } = options;
+
+  return useMemo(() => {
+    let filtered = rawPosts;
+
+    if (selectedTags.length > 0) {
+      filtered = filtered.filter((post) => selectedTags.some((tag) => post.tags.includes(tag)));
+    }
+
+    if (sort === 'POPULAR') {
+      filtered = filtered
+        .filter((post) => post.stats.likeCount >= POPULAR_MIN_LIKES)
+        .sort((a, b) => {
+          if (b.stats.likeCount !== a.stats.likeCount) {
+            return b.stats.likeCount - a.stats.likeCount;
+          }
+          return (
+            parseBoardDateTime(b.createdAt).getTime() - parseBoardDateTime(a.createdAt).getTime()
+          );
+        });
+    }
+
+    if (sort === 'FOLLOWING') {
+      const followingAuthorIdSet = new Set(followingAuthorIds ?? []);
+      filtered = filtered.filter((post) => followingAuthorIdSet.has(post.author.userId));
+    }
+
+    return filtered;
+  }, [rawPosts, selectedTags, sort, followingAuthorIds]);
+}

--- a/src/screens/board/BoardCreatePage.tsx
+++ b/src/screens/board/BoardCreatePage.tsx
@@ -24,21 +24,28 @@ import { BOARD_CONTENT_MAX_LENGTH, BOARD_TITLE_MAX_LENGTH } from '@/constants/bo
 import { createBoardPost } from '@/lib/api/boards';
 import { ApiError } from '@/lib/errors/ApiError';
 import { useBoardAttachments } from '@/lib/hooks/boards/useBoardAttachments';
+import { useBoardForm } from '@/lib/hooks/boards/useBoardForm';
 import { toast } from '@/lib/toast/store';
 import { uploadFile } from '@/lib/upload/uploadFile';
 import { validateFiles } from '@/lib/validators/attachment';
-import { validateBoardCreateContent, validateBoardCreateTitle } from '@/lib/validators/boardCreate';
 
-import type { BoardTag } from '@/types/board';
 import type { BoardAttachment } from '@/types/boardCreate';
 
 export default function BoardCreatePage() {
   const router = useRouter();
   const { setOptions, resetOptions } = useHeader();
-  const [title, setTitle] = useState('');
-  const [content, setContent] = useState('');
-  const [isPreview, setIsPreview] = useState(false);
-  const [tags, setTags] = useState<BoardTag[]>([]);
+  const {
+    title,
+    setTitle,
+    content,
+    setContent,
+    isPreview,
+    setIsPreview,
+    tags,
+    setTags,
+    titleError,
+    isSubmitEnabled,
+  } = useBoardForm();
   const {
     attachments,
     addAttachments,
@@ -51,9 +58,6 @@ export default function BoardCreatePage() {
   const [maskAttachment, setMaskAttachment] = useState<BoardAttachment | null>(null);
   const imageInputRef = useRef<HTMLInputElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const titleError = useMemo(() => validateBoardCreateTitle(title), [title]);
-  const contentError = useMemo(() => validateBoardCreateContent(content), [content]);
-  const isSubmitEnabled = useMemo(() => !titleError && !contentError, [contentError, titleError]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [fileTooLargeOpen, setFileTooLargeOpen] = useState(false);
   const [unsupportedFileOpen, setUnsupportedFileOpen] = useState(false);
@@ -176,7 +180,7 @@ export default function BoardCreatePage() {
     if (action) {
       action();
     }
-  }, [clearAttachments]);
+  }, [clearAttachments, setContent, setIsPreview, setTags, setTitle]);
 
   const handleExitCancel = useCallback(() => {
     pendingNavigationRef.current = null;

--- a/src/screens/board/BoardEditPage.tsx
+++ b/src/screens/board/BoardEditPage.tsx
@@ -26,10 +26,10 @@ import { ApiError } from '@/lib/errors/ApiError';
 import { boardsKeys } from '@/lib/hooks/boards/queryKeys';
 import { useBoardAttachments } from '@/lib/hooks/boards/useBoardAttachments';
 import { useBoardDetailQuery } from '@/lib/hooks/boards/useBoardDetailQuery';
+import { useBoardForm } from '@/lib/hooks/boards/useBoardForm';
 import { toast } from '@/lib/toast/store';
 import { uploadFile } from '@/lib/upload/uploadFile';
 import { validateFiles } from '@/lib/validators/attachment';
-import { validateBoardCreateContent, validateBoardCreateTitle } from '@/lib/validators/boardCreate';
 
 import type { BoardTag } from '@/types/board';
 import type { BoardAttachment, BoardAttachmentType } from '@/types/boardCreate';
@@ -93,10 +93,18 @@ export default function BoardEditPage() {
   }, [postIdParam]);
   const { data: post, isLoading, isError, refetch } = useBoardDetailQuery(postId);
 
-  const [title, setTitle] = useState('');
-  const [content, setContent] = useState('');
-  const [isPreview, setIsPreview] = useState(false);
-  const [tags, setTags] = useState<BoardTag[]>([]);
+  const {
+    title,
+    setTitle,
+    content,
+    setContent,
+    isPreview,
+    setIsPreview,
+    tags,
+    setTags,
+    titleError,
+    isSubmitEnabled,
+  } = useBoardForm();
   const {
     attachments,
     setAttachments,
@@ -120,10 +128,6 @@ export default function BoardEditPage() {
   const [exitConfirmOpen, setExitConfirmOpen] = useState(false);
   const pendingNavigationRef = useRef<(() => void) | null>(null);
 
-  const titleError = useMemo(() => validateBoardCreateTitle(title), [title]);
-  const contentError = useMemo(() => validateBoardCreateContent(content), [content]);
-  const isSubmitEnabled = useMemo(() => !titleError && !contentError, [contentError, titleError]);
-
   useEffect(() => {
     didBindInitialRef.current = false;
     setTitle('');
@@ -131,7 +135,7 @@ export default function BoardEditPage() {
     setTags([]);
     setInitialSnapshot(null);
     clearAttachments();
-  }, [clearAttachments, postId]);
+  }, [clearAttachments, postId, setContent, setTags, setTitle]);
 
   useEffect(() => {
     if (!post) return;
@@ -156,7 +160,7 @@ export default function BoardEditPage() {
       ),
     });
     didBindInitialRef.current = true;
-  }, [post, setAttachments]);
+  }, [post, setAttachments, setContent, setTags, setTitle]);
 
   const readyFileIds = useMemo(
     () =>

--- a/src/screens/board/BoardListPage.tsx
+++ b/src/screens/board/BoardListPage.tsx
@@ -16,7 +16,6 @@ import {
   BOARD_PAGE_SIZE,
   BOARD_TAG_MAX,
   FOLLOWINGS_FETCH_SIZE,
-  POPULAR_MIN_LIKES,
   PULL_MAX,
   PULL_THRESHOLD,
 } from '@/constants/board';
@@ -24,9 +23,9 @@ import { fetchMyFollowings } from '@/lib/api/users';
 import { getUserIdFromAccessToken } from '@/lib/auth/token';
 import { useBoardListInfiniteQuery } from '@/lib/hooks/boards/useBoardListInfiniteQuery';
 import { useBoardMiniProfile } from '@/lib/hooks/boards/useBoardMiniProfile';
+import { useFilteredPosts } from '@/lib/hooks/boards/useFilteredPosts';
 import { useUnreadCountQuery } from '@/lib/hooks/notifications/useUnreadCountQuery';
 import { userKeys } from '@/lib/hooks/users/queryKeys';
-import { parseBoardDateTime } from '@/lib/utils/board';
 
 import type { BoardSort, BoardTag } from '@/types/board';
 
@@ -109,33 +108,7 @@ export default function BoardListPage() {
     enabled: sort === 'FOLLOWING',
   });
 
-  const filteredPosts = useMemo(() => {
-    let filtered = rawPosts;
-
-    if (selectedTags.length > 0) {
-      filtered = filtered.filter((post) => selectedTags.some((tag) => post.tags.includes(tag)));
-    }
-
-    if (sort === 'POPULAR') {
-      filtered = filtered
-        .filter((post) => post.stats.likeCount >= POPULAR_MIN_LIKES)
-        .sort((a, b) => {
-          if (b.stats.likeCount !== a.stats.likeCount) {
-            return b.stats.likeCount - a.stats.likeCount;
-          }
-          return (
-            parseBoardDateTime(b.createdAt).getTime() - parseBoardDateTime(a.createdAt).getTime()
-          );
-        });
-    }
-
-    if (sort === 'FOLLOWING') {
-      const followingAuthorIdSet = new Set(followingAuthorIds ?? []);
-      filtered = filtered.filter((post) => followingAuthorIdSet.has(post.author.userId));
-    }
-
-    return filtered;
-  }, [rawPosts, selectedTags, sort, followingAuthorIds]);
+  const filteredPosts = useFilteredPosts(rawPosts, { sort, selectedTags, followingAuthorIds });
 
   const handleCreatePost = useCallback(() => {
     requestNavigation(() => router.push('/board/create'));

--- a/src/screens/board/BoardListPage.tsx
+++ b/src/screens/board/BoardListPage.tsx
@@ -20,15 +20,12 @@ import {
   PULL_MAX,
   PULL_THRESHOLD,
 } from '@/constants/board';
-import { fetchMyFollowings, fetchUserProfile } from '@/lib/api/users';
+import { fetchMyFollowings } from '@/lib/api/users';
 import { getUserIdFromAccessToken } from '@/lib/auth/token';
-import { ApiError } from '@/lib/errors/ApiError';
 import { useBoardListInfiniteQuery } from '@/lib/hooks/boards/useBoardListInfiniteQuery';
+import { useBoardMiniProfile } from '@/lib/hooks/boards/useBoardMiniProfile';
 import { useUnreadCountQuery } from '@/lib/hooks/notifications/useUnreadCountQuery';
 import { userKeys } from '@/lib/hooks/users/queryKeys';
-import { useFollowUserMutation } from '@/lib/hooks/users/useFollowUserMutation';
-import { useUnfollowUserMutation } from '@/lib/hooks/users/useUnfollowUserMutation';
-import { toast } from '@/lib/toast/store';
 import { parseBoardDateTime } from '@/lib/utils/board';
 
 import type { BoardSort, BoardTag } from '@/types/board';
@@ -43,17 +40,12 @@ export default function BoardListPage() {
   const [sort, setSort] = useState<BoardSort>('LATEST');
   const [selectedTags, setSelectedTags] = useState<BoardTag[]>([]);
   const [isTagOpen, setIsTagOpen] = useState(false);
-  const [isMiniProfileOpen, setIsMiniProfileOpen] = useState(false);
-  const [selectedAuthorId, setSelectedAuthorId] = useState<number | null>(null);
-  const [followStateOverrides, setFollowStateOverrides] = useState<Record<number, boolean>>({});
   const [pullDistance, setPullDistance] = useState(0);
   const [isPulling, setIsPulling] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [isReadyToRefresh, setIsReadyToRefresh] = useState(false);
   const isRefreshingRef = useRef(false);
   const isReadyToRefreshRef = useRef(false);
-  const followMutation = useFollowUserMutation();
-  const unfollowMutation = useUnfollowUserMutation();
 
   const { data, isLoading, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useBoardListInfiniteQuery({
@@ -63,6 +55,19 @@ export default function BoardListPage() {
     });
 
   const rawPosts = useMemo(() => data?.pages.flatMap((page) => page.items) ?? [], [data]);
+
+  const {
+    isMiniProfileOpen,
+    setIsMiniProfileOpen,
+    modalUser,
+    modalUserId,
+    isMine,
+    isFollowing,
+    isFollowPending,
+    handleAuthorClick,
+    handleToggleFollow,
+  } = useBoardMiniProfile({ rawPosts, currentUserId });
+
   const {
     data: followingAuthorIds,
     isLoading: isFollowingAuthorIdsLoading,
@@ -132,48 +137,6 @@ export default function BoardListPage() {
     return filtered;
   }, [rawPosts, selectedTags, sort, followingAuthorIds]);
 
-  const selectedAuthor = useMemo(
-    () => rawPosts.find((post) => post.author.userId === selectedAuthorId)?.author ?? null,
-    [rawPosts, selectedAuthorId],
-  );
-  const { data: selectedAuthorProfile, refetch: refetchSelectedAuthorProfile } = useQuery({
-    queryKey: userKeys.profile(selectedAuthorId ?? -1),
-    queryFn: async () => {
-      const result = await fetchUserProfile(selectedAuthorId!);
-
-      if (!result.ok || !result.json) {
-        throw new Error('Failed to fetch user profile');
-      }
-
-      if ('data' in result.json && result.json.data) {
-        return result.json.data;
-      }
-
-      throw new Error('Invalid response format');
-    },
-    enabled: selectedAuthorId !== null,
-  });
-
-  const modalUser = selectedAuthor
-    ? {
-        userId: selectedAuthor.userId,
-        nickname: selectedAuthorProfile?.user.nickname ?? selectedAuthor.nickname,
-        profileImageUrl:
-          selectedAuthorProfile?.profileImage?.url ?? selectedAuthor.profileImageUrl ?? null,
-        interests: selectedAuthorProfile?.interests ?? selectedAuthor.interests ?? [],
-      }
-    : null;
-  const modalUserId = modalUser?.userId ?? null;
-  const isMine = Boolean(
-    modalUserId !== null && currentUserId !== null && modalUserId === currentUserId,
-  );
-  const profileIsFollowing = selectedAuthorProfile?.isFollowing ?? false;
-  const isFollowing =
-    modalUserId !== null && followStateOverrides[modalUserId] !== undefined
-      ? followStateOverrides[modalUserId]
-      : profileIsFollowing;
-  const isFollowPending = followMutation.isPending || unfollowMutation.isPending;
-
   const handleCreatePost = useCallback(() => {
     requestNavigation(() => router.push('/board/create'));
   }, [requestNavigation, router]);
@@ -185,29 +148,6 @@ export default function BoardListPage() {
   const handleNotificationsClick = useCallback(() => {
     requestNavigation(() => router.push('/notifications'));
   }, [requestNavigation, router]);
-
-  const handleAuthorClick = (userId: number) => {
-    setSelectedAuthorId(userId);
-    setIsMiniProfileOpen(true);
-  };
-
-  const handleToggleFollow = async () => {
-    if (modalUserId === null || isMine || isFollowPending) return;
-
-    try {
-      if (isFollowing) {
-        await unfollowMutation.mutateAsync(modalUserId);
-        setFollowStateOverrides((prev) => ({ ...prev, [modalUserId]: false }));
-      } else {
-        await followMutation.mutateAsync(modalUserId);
-        setFollowStateOverrides((prev) => ({ ...prev, [modalUserId]: true }));
-      }
-      void refetchSelectedAuthorProfile();
-    } catch (error) {
-      const err = ApiError.fromUnknown(error);
-      toast(err.serverMessage ?? '팔로우 처리에 실패했습니다.');
-    }
-  };
 
   const handlePostClick = useCallback(
     (postId: number) => {


### PR DESCRIPTION
## 📌 작업한 내용

  Board 관련 페이지(BoardListPage, BoardCreatePage, BoardEditPage)에 인라인으로      
  누적되어 있던 상태·로직을 Custom Hook으로 분리하여 각 컴포넌트의 단일 책임을       
  개선했습니다.                                                                      
                                                                                     
  useBoardMiniProfile 추출 (BoardListPage)                                           
  - 미니프로필 모달 관련 상태(selectedAuthorId, followStateOverrides,
  isMiniProfileOpen)와 팔로우 mutation, 작성자 프로필 조회, handleAuthorClick /
  handleToggleFollow 핸들러를 훅으로 분리
  - 라우팅 콜백(onGoMyPage, onStartChat)은 부모에 유지

  useFilteredPosts 추출 (BoardListPage)
  - 태그 필터 → POPULAR 정렬 → FOLLOWING 필터가 하나의 useMemo에 결합되어 있던 로직을
   훅으로 분리
  - POPULAR_MIN_LIKES, parseBoardDateTime 의존성을 훅 내부로 캡슐화

  useBoardForm 추출 (BoardCreatePage, BoardEditPage)
  - 두 페이지에 동일하게 선언되어 있던 title/content/isPreview/tags 상태 4개와
  titleError/contentError/isSubmitEnabled 파생값 3개를 훅으로 통합
  - submit 로직, 초기값 바인딩, dirty 감지 등 페이지별 차이가 있는 로직은 각 파일에
  유지

## 🔍 참고 사항

  - UI 동작 변경 없음 — 순수 리팩토링
  - 신규 훅 3개 모두 src/lib/hooks/boards/ 하위에 위치
  - useBoardForm의 contentError는 훅 내부에서 isSubmitEnabled 계산에만 사용되며 각
  페이지 JSX에서는 직접 참조하지 않으므로 destructuring에서 제외

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
- [ ] (채팅) `/api/chatrooms` pagination에서 서버 cursor 재사용 원칙 준수 확인
