### PR TITLE
perf: S3 도메인 preconnect 힌트 추가로 이미지 로드 연결 지연 개선

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -40,6 +40,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        <link rel="preconnect" href="https://devths-storage-prod.s3.ap-northeast-2.amazonaws.com" />
+      </head>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         {GA_MEASUREMENT_ID ? (
           <>


### PR DESCRIPTION
## 📌 작업한 내용

  layout.tsx <head>에 S3 도메인 preconnect 힌트를 추가했습니다.                      
                 
  브라우저가 HTML 파싱 초기에 S3 도메인과의 TCP/TLS 연결을 선제적으로 수립해, 이미지 요청 시 연결 지연을 줄입니다. 

## 🔍 참고 사항

  - Lighthouse 분석에서 LCP 7.5초가 측정됐으며, S3 이미지 로드 시 발생하는 연결 수립 지연(DNS + TCP + TLS)이 원인 중 하나로 확인됨
  - LCP 근본 원인(이미지 용량, CDN 미사용)은 인프라 변경이 필요하므로 이 PR에서는 다루지 않음

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
