### PR TITLE
[#193] refactor: beforeunload 핸들러 제거로 bfcache 차단 해소

### DIFF
--- a/src/components/layout/AppFrame.tsx
+++ b/src/components/layout/AppFrame.tsx
@@ -191,19 +191,11 @@ export default function AppFrame({
       toast(blockMessage);
     };
 
-    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-      if (!isNavigationBlocked) return;
-      event.preventDefault();
-      event.returnValue = '';
-    };
-
     window.history.pushState(null, '', window.location.href);
     window.addEventListener('popstate', handlePopState);
-    window.addEventListener('beforeunload', handleBeforeUnload);
 
     return () => {
       window.removeEventListener('popstate', handlePopState);
-      window.removeEventListener('beforeunload', handleBeforeUnload);
     };
   }, [blockMessage, isNavigationBlocked]);
 


### PR DESCRIPTION
## 📌 작업한 내용

  AppFrame.tsx에서 beforeunload 이벤트 핸들러를 제거했습니다.                        
                                                                                     
  Lighthouse 진단에서 /board 페이지의 뒤로-앞으로 캐시(bfcache) 복원이 차단되는 원인 중 하나로 beforeunload 핸들러가 지목됐습니다. 브라우저는 beforeunload 핸들러가 등록된 페이지를 bfcache에 저장하지 않아, 뒤로/앞으로 탐색 시 페이지를 처음부터 다시 로드하게 됩니다.                                                                  

  beforeunload를 제거해 bfcache 차단을 해소했습니다. SPA 내부 뒤로가기 차단은 popstate 핸들러로 유지됩니다.

## 🔍 참고 사항

  - beforeunload가 제공하던 탭 닫기/새로고침 시 "페이지를 떠나시겠습니까?" 브라우저 기본 다이얼로그는 제거됩니다.
  - 게시글 작성·수정 중 SPA 내부 이동(뒤로가기, 다른 메뉴 탭 이동) 차단은 popstate 핸들러로 그대로 동작합니다.
  - bfcache 실패 이유 중 "WebSocket이 있는 페이지에서는 뒤로-앞으로 캐시를 시작할 수 없습니다."는 브라우저 스펙 문제로 코드 단에서 해결 불가합니다.

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

Ref #193 

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
- [ ] (채팅) `/api/chatrooms` pagination에서 서버 cursor 재사용 원칙 준수 확인
