### PR TITLE
perf: 렌더링 차단 CSS 스코프 축소 및 프로필 이미지 업로드 최적화

### DIFF
--- a/src/app/(app)/calendar/layout.tsx
+++ b/src/app/(app)/calendar/layout.tsx
@@ -1,0 +1,7 @@
+import '@/styles/fullcalendar.css';
+
+import type { ReactNode } from 'react';
+
+export default function CalendarLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,5 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
-/* FullCalendar v6 base styles (vendored from global builds to avoid package export issues) */
-@import '../styles/fullcalendar.css';
 
 @custom-variant dark (&:is(.dark *));
 

--- a/src/components/mypage/EditProfileModal.tsx
+++ b/src/components/mypage/EditProfileModal.tsx
@@ -14,6 +14,7 @@ import { useDeleteProfileImageMutation } from '@/lib/hooks/users/useDeleteProfil
 import { useUpdateMeMutation } from '@/lib/hooks/users/useUpdateMeMutation';
 import { useUploadProfileImageMutation } from '@/lib/hooks/users/useUpdateProfileImageMutation';
 import { toast } from '@/lib/toast/store';
+import { resizeProfileImage } from '@/lib/utils/resizeProfileImage';
 import { validateNickname } from '@/lib/utils/validateNickname';
 
 import type { MeData } from '@/lib/api/users';
@@ -68,10 +69,16 @@ function EditForm({ initialData, onClose, onWithdraw }: EditFormProps) {
     setSubmitMessage(null);
   };
 
-  const handleSelectImage = (file: File) => {
-    const url = URL.createObjectURL(file);
+  const handleSelectImage = async (file: File) => {
+    let fileToUse = file;
+    try {
+      fileToUse = await resizeProfileImage(file);
+    } catch {
+      // 리사이즈 실패 시 원본 파일 사용
+    }
+    const url = URL.createObjectURL(fileToUse);
     setPreviewUrl(url);
-    setSelectedFile(file);
+    setSelectedFile(fileToUse);
     setIsProfileImageDeleted(false);
     setSubmitMessage(null);
   };

--- a/src/lib/utils/resizeProfileImage.ts
+++ b/src/lib/utils/resizeProfileImage.ts
@@ -1,0 +1,49 @@
+const PROFILE_MAX_PX = 256;
+const PROFILE_QUALITY = 0.85;
+
+export async function resizeProfileImage(file: File): Promise<File> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    const objectUrl = URL.createObjectURL(file);
+
+    img.onload = () => {
+      URL.revokeObjectURL(objectUrl);
+
+      const { width, height } = img;
+      const scale = Math.min(PROFILE_MAX_PX / width, PROFILE_MAX_PX / height, 1);
+      const w = Math.round(width * scale);
+      const h = Math.round(height * scale);
+
+      const canvas = document.createElement('canvas');
+      canvas.width = w;
+      canvas.height = h;
+
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        reject(new Error('Canvas context를 생성할 수 없습니다.'));
+        return;
+      }
+
+      ctx.drawImage(img, 0, 0, w, h);
+
+      canvas.toBlob(
+        (blob) => {
+          if (!blob) {
+            reject(new Error('이미지 변환에 실패했습니다.'));
+            return;
+          }
+          resolve(new File([blob], 'profile.webp', { type: 'image/webp' }));
+        },
+        'image/webp',
+        PROFILE_QUALITY,
+      );
+    };
+
+    img.onerror = () => {
+      URL.revokeObjectURL(objectUrl);
+      reject(new Error('이미지를 로드할 수 없습니다.'));
+    };
+
+    img.src = objectUrl;
+  });
+}

--- a/src/screens/SignupPage.tsx
+++ b/src/screens/SignupPage.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/lib/auth/token';
 import { toast } from '@/lib/toast/store';
 import { uploadToPresignedUrl } from '@/lib/upload/s3Presigned';
+import { resizeProfileImage } from '@/lib/utils/resizeProfileImage';
 import { getNicknameErrorMessage } from '@/lib/validators/nickname';
 
 export default function SignupPage() {
@@ -138,9 +139,16 @@ export default function SignupPage() {
 
   const handleSelectProfile = async (file: File) => {
     if (profilePreviewUrl) URL.revokeObjectURL(profilePreviewUrl);
-    setProfilePreviewUrl(URL.createObjectURL(file));
 
-    await uploadProfileImage(file);
+    let fileToUpload = file;
+    try {
+      fileToUpload = await resizeProfileImage(file);
+    } catch {
+      // 리사이즈 실패 시 원본 파일 사용
+    }
+
+    setProfilePreviewUrl(URL.createObjectURL(fileToUpload));
+    await uploadProfileImage(fileToUpload);
   };
 
   const handleSubmit = async () => {


### PR DESCRIPTION
## 📌 작업한 내용

  Lighthouse 성능 진단을 기반으로 렌더링 차단 리소스 제거와 이미지 전송 최적화를             
  적용했습니다.                                                                              
                                                                                             
  1. FullCalendar CSS 스코프 축소 (b4af106)                                                  
  - globals.css에서 fullcalendar.css 전역 import 제거                                        
  - src/app/(app)/calendar/layout.tsx 생성 → 캘린더 라우트에서만 로드하도록 변경
  - 캘린더 외 모든 페이지의 렌더링 차단 CSS ~10KB 제거

  2. 프로필 이미지 업로드 전 Canvas 리사이즈 (225010c)
  - src/lib/utils/resizeProfileImage.ts 유틸 추가
    - Canvas API로 256×256 이하 리사이즈 + WebP 85% 압축
    - 리사이즈 실패 시 원본 파일 사용 (fallback)
  - SignupPage.tsx, EditProfileModal.tsx 양쪽에 적용

## 🔍 참고 사항

  - FullCalendar CSS: 캘린더 페이지에서는 기존과 동일하게 동작하며, 다른 페이지(LLM, 채팅 등)에서 불필요하게 로드되던 렌더링 차단 리소스가 제거됩니다. Lighthouse 렌더링 차단 요청 120ms 개선 예상.
  - 프로필 이미지: /api/files/presigned/signup은 image/webp를 허용하고 있으며, /api/files/presigned는 MIME 타입 검증이 없어 양쪽 모두 WebP 업로드가 정상 동작합니다. 기존 902KB PNG → 약 20~30KB WebP로 감소 예상.

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
- [ ] (채팅) `/api/chatrooms` pagination에서 서버 cursor 재사용 원칙 준수 확인
