### PR TITLE
perf: 게시판 LCP 이미지 priority 적용으로 초기 로드 개선

### DIFF
--- a/src/components/board/BoardPostCard.tsx
+++ b/src/components/board/BoardPostCard.tsx
@@ -11,9 +11,15 @@ type BoardPostCardProps = {
   post: BoardPostSummary;
   onClick?: (postId: number) => void;
   onAuthorClick?: (userId: number) => void;
+  priority?: boolean;
 };
 
-export default function BoardPostCard({ post, onClick, onAuthorClick }: BoardPostCardProps) {
+export default function BoardPostCard({
+  post,
+  onClick,
+  onAuthorClick,
+  priority = false,
+}: BoardPostCardProps) {
   const handleCardClick = () => {
     onClick?.(post.postId);
   };
@@ -49,6 +55,7 @@ export default function BoardPostCard({ post, onClick, onAuthorClick }: BoardPos
               fill
               sizes="40px"
               className="rounded-full object-cover"
+              priority={priority}
             />
           ) : (
             <span>{post.author.nickname.slice(0, 1)}</span>

--- a/src/screens/board/BoardListPage.tsx
+++ b/src/screens/board/BoardListPage.tsx
@@ -351,12 +351,13 @@ export default function BoardListPage() {
               </p>
             ) : (
               <>
-                {filteredPosts.map((post) => (
+                {filteredPosts.map((post, index) => (
                   <BoardPostCard
                     key={post.postId}
                     post={post}
                     onClick={handlePostClick}
                     onAuthorClick={handleAuthorClick}
+                    priority={index === 0}
                   />
                 ))}
                 <div className="px-4 pt-2">


### PR DESCRIPTION
## 📌 작업한 내용

  Lighthouse LCP 진단에서 게시판 첫 번째 프로필 이미지가 LCP 요소로 감지되었으나 loading="lazy"가 적용되어 로드가 지연되는 문제를 수정했습니다.       
                                                      
  - BoardPostCard에 priority prop 추가                
  - BoardListPage에서 첫 번째 카드(index === 0)에만 priority={true} 전달
  - 나머지 카드는 기존 lazy loading 유지

## 🔍 참고 사항

  Next.js <Image>의 priority prop을 적용하면
  - loading="lazy" → loading="eager"로 변경
  - <head>에 <link rel="preload">가 자동 삽입되어 브라우저가 페이지 로드 초기에 해당 이미지를 즉시 요청

  첫 번째 카드에만 적용하여 불필요한 대역폭 낭비를 방지했습니다.

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
- [ ] (채팅) `/api/chatrooms` pagination에서 서버 cursor 재사용 원칙 준수 확인
