### PR TITLE
fix: 수정 모드 이미지 재마스킹 시 canvas taint SecurityError 수정

### DIFF
--- a/src/app/api/image-proxy/route.ts
+++ b/src/app/api/image-proxy/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const ALLOWED_S3_HOSTNAME = /^[\w-]+\.s3\.[\w-]+\.amazonaws\.com$/;
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const url = searchParams.get('url');
+
+  if (!url) {
+    return NextResponse.json({ error: 'Missing url parameter' }, { status: 400 });
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return NextResponse.json({ error: 'Invalid url parameter' }, { status: 400 });
+  }
+
+  if (!ALLOWED_S3_HOSTNAME.test(parsed.hostname)) {
+    return NextResponse.json({ error: 'Disallowed host' }, { status: 400 });
+  }
+
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      return new NextResponse(null, { status: response.status });
+    }
+
+    const blob = await response.blob();
+    const contentType = response.headers.get('content-type') ?? 'application/octet-stream';
+
+    return new NextResponse(blob, {
+      headers: {
+        'Content-Type': contentType,
+        'Cache-Control': 'public, max-age=3600, immutable',
+      },
+    });
+  } catch {
+    return new NextResponse(null, { status: 502 });
+  }
+}

--- a/src/components/board/BoardAttachmentMaskModal.tsx
+++ b/src/components/board/BoardAttachmentMaskModal.tsx
@@ -61,9 +61,12 @@ export default function BoardAttachmentMaskModal({
 
     let tempUrl: string | null = null;
     const image = new Image();
-    image.crossOrigin = 'anonymous';
     if (attachment.previewUrl) {
-      image.src = attachment.previewUrl;
+      if (attachment.previewUrl.startsWith('blob:')) {
+        image.src = attachment.previewUrl;
+      } else {
+        image.src = `/api/image-proxy?url=${encodeURIComponent(attachment.previewUrl)}`;
+      }
     } else {
       tempUrl = URL.createObjectURL(attachment.file);
       image.src = tempUrl;

--- a/src/components/board/BoardAttachmentMaskModal.tsx
+++ b/src/components/board/BoardAttachmentMaskModal.tsx
@@ -61,6 +61,7 @@ export default function BoardAttachmentMaskModal({
 
     let tempUrl: string | null = null;
     const image = new Image();
+    image.crossOrigin = 'anonymous';
     if (attachment.previewUrl) {
       image.src = attachment.previewUrl;
     } else {


### PR DESCRIPTION
## 📌 작업한 내용

  게시글 수정 모드에서 기존 이미지에 **개인정보 가리기**를 재시도할 때 발생하는 `SecurityError: The canvas has been tainted by cross-origin data` 버그를 수정했습니다.                                                                                    
                                                                                                                              
  **원인**                                                                                                                    
  - 게시글 수정 모드 진입 시 이미지의 `previewUrl`은 S3 URL(cross-origin)                                                     
  - `BoardAttachmentMaskModal`에서 해당 URL을 `crossOrigin` 설정 없이 `<canvas>`에 그리면 canvas가 오염(tainted)됨
  - 이후 모자이크 처리에 필요한 `ctx.getImageData()` 호출 시 SecurityError 발생

  **해결**
  - S3 버킷에 CORS 정책이 없어 `crossOrigin = 'anonymous'` 방식으로는 해결 불가
  - `/api/image-proxy` API 라우트를 추가하여 Next.js 서버가 S3 이미지를 중계
  - 마스킹 모달에서 blob URL이 아닌 외부 URL은 프록시를 통해 로드하도록 수정
  - 브라우저 입장에서 동일 출처 요청이 되어 canvas taint 없이 `getImageData()` 정상 동작

## 🔍 참고 사항

  - `/api/image-proxy`는 S3 hostname 패턴(`*.s3.*.amazonaws.com`) 검증을 통해 SSRF 방지
  - 게시글 **작성 시** 첫 마스킹은 `blob:` URL을 사용하므로 영향 없음
  - 프록시 응답에 `Cache-Control: public, max-age=3600` 적용

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

Ref #198

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
- [ ] (채팅) `/api/chatrooms` pagination에서 서버 cursor 재사용 원칙 준수 확인
