### PR TITLE
fix: 게시글/댓글 텍스트 overflow 및 알림 시간 오차 수정

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -158,7 +158,7 @@
   }
 
   .markdown-preview p {
-    @apply break-all text-sm text-neutral-700;
+    @apply text-sm break-all text-neutral-700;
   }
 
   .markdown-preview ul {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -158,7 +158,7 @@
   }
 
   .markdown-preview p {
-    @apply text-sm text-neutral-700;
+    @apply break-all text-sm text-neutral-700;
   }
 
   .markdown-preview ul {
@@ -178,7 +178,7 @@
   }
 
   .markdown-preview .md-pre {
-    @apply my-3 rounded-xl bg-neutral-100 px-3 py-2 text-xs text-neutral-800;
+    @apply my-3 overflow-x-auto rounded-xl bg-neutral-100 px-3 py-2 text-xs text-neutral-800;
   }
 
   .markdown-preview .md-inline {

--- a/src/components/board/detail/CommentItem.tsx
+++ b/src/components/board/detail/CommentItem.tsx
@@ -137,7 +137,12 @@ export default function CommentItem({
         ) : null}
       </div>
       {isEditing ? null : (
-        <p className={cn('mt-2 break-all text-xs', isDeleted ? 'text-neutral-400' : 'text-neutral-600')}>
+        <p
+          className={cn(
+            'mt-2 text-xs break-all',
+            isDeleted ? 'text-neutral-400' : 'text-neutral-600',
+          )}
+        >
           {isDeleted ? '삭제된 댓글입니다.' : content}
         </p>
       )}

--- a/src/components/board/detail/CommentItem.tsx
+++ b/src/components/board/detail/CommentItem.tsx
@@ -137,7 +137,7 @@ export default function CommentItem({
         ) : null}
       </div>
       {isEditing ? null : (
-        <p className={cn('mt-2 text-xs', isDeleted ? 'text-neutral-400' : 'text-neutral-600')}>
+        <p className={cn('mt-2 break-all text-xs', isDeleted ? 'text-neutral-400' : 'text-neutral-600')}>
           {isDeleted ? '삭제된 댓글입니다.' : content}
         </p>
       )}

--- a/src/components/board/detail/PostContent.tsx
+++ b/src/components/board/detail/PostContent.tsx
@@ -33,7 +33,7 @@ export default function PostContent({
 
   return (
     <div className="mt-3">
-      <h1 className="text-xl font-semibold text-neutral-900">{title}</h1>
+      <h1 className="break-all text-xl font-semibold text-neutral-900">{title}</h1>
       {trimmed.length > 0 ? (
         <div className="markdown-preview mt-2 text-sm" dangerouslySetInnerHTML={{ __html: html }} />
       ) : (

--- a/src/components/board/detail/PostContent.tsx
+++ b/src/components/board/detail/PostContent.tsx
@@ -33,7 +33,7 @@ export default function PostContent({
 
   return (
     <div className="mt-3">
-      <h1 className="break-all text-xl font-semibold text-neutral-900">{title}</h1>
+      <h1 className="text-xl font-semibold break-all text-neutral-900">{title}</h1>
       {trimmed.length > 0 ? (
         <div className="markdown-preview mt-2 text-sm" dangerouslySetInnerHTML={{ __html: html }} />
       ) : (

--- a/src/components/board/detail/ReplyItem.tsx
+++ b/src/components/board/detail/ReplyItem.tsx
@@ -134,7 +134,12 @@ export default function ReplyItem({
           ) : null}
         </div>
         {isEditing ? null : (
-          <p className={cn('mt-2 break-all text-xs', isDeleted ? 'text-neutral-400' : 'text-neutral-600')}>
+          <p
+            className={cn(
+              'mt-2 text-xs break-all',
+              isDeleted ? 'text-neutral-400' : 'text-neutral-600',
+            )}
+          >
             {isDeleted ? '삭제된 댓글입니다.' : content}
           </p>
         )}

--- a/src/components/board/detail/ReplyItem.tsx
+++ b/src/components/board/detail/ReplyItem.tsx
@@ -134,7 +134,7 @@ export default function ReplyItem({
           ) : null}
         </div>
         {isEditing ? null : (
-          <p className={cn('mt-2 text-xs', isDeleted ? 'text-neutral-400' : 'text-neutral-600')}>
+          <p className={cn('mt-2 break-all text-xs', isDeleted ? 'text-neutral-400' : 'text-neutral-600')}>
             {isDeleted ? '삭제된 댓글입니다.' : content}
           </p>
         )}

--- a/src/lib/utils/notifications.ts
+++ b/src/lib/utils/notifications.ts
@@ -8,7 +8,7 @@ function parseKstDate(isoString: string) {
     return new Date(normalized);
   }
 
-  return new Date(`${normalized}+09:00`);
+  return new Date(`${normalized}Z`);
 }
 
 export function formatNotificationDate(isoString: string): string {


### PR DESCRIPTION
## 📌 작업한 내용

  ### 1. 긴 문자열 입력 시 overflow 수정                                            
  공백 없는 긴 문자열(예: `~~~~...`, 긴 URL 등)을 게시글/댓글에 입력하면 텍스트가 컨테이너 밖으로 튀어나오는 문제를 수정했습니다.                                   
                                                                                    
  - 게시글 제목(`PostContent` h1)에 `break-all` 추가                                
  - 마크다운 본문 `p` 태그(`.markdown-preview p`)에 `break-all` 추가
  - 댓글(`CommentItem`) 및 답글(`ReplyItem`) 내용 `p` 태그에 `break-all` 추가
  - 코드 블록(`.md-pre`)에 `overflow-x-auto` 추가하여 긴 코드는 가로 스크롤 처리

  ### 2. 알림 시간 9시간 오차 수정
  알림 목록에서 표시되는 시간이 실제보다 9시간 이른 문제를 수정했습니다.

  - `parseKstDate` 함수에서 timezone 정보가 없는 날짜 문자열에 `+09:00`(KST)을
  붙이고 있었으나, 서버가 UTC 기준으로 시간을 전달하므로 `Z`(UTC)로 변경

## 🔍 참고 사항

  - 코드 블록은 `break-all` 대신 `overflow-x-auto`를 적용하여 코드 가독성 유지
  - 알림 외 게시글/댓글 등 다른 시간 파싱 유틸리티는 별도 함수 사용 중으로 영향 없음

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

Ref #200

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
- [ ] (채팅) `/api/chatrooms` pagination에서 서버 cursor 재사용 원칙 준수 확인
