### PR TITLE
[#202] feat: 마이페이지 푸시 알림 토글 도입 및 FCM 토큰 동기화 개선

### DIFF
--- a/src/components/layout/AppFrame.tsx
+++ b/src/components/layout/AppFrame.tsx
@@ -14,7 +14,6 @@ import { ensureAccessToken } from '@/lib/api/client';
 import { clearAccessToken, getUserIdFromAccessToken, setAuthRedirect } from '@/lib/auth/token';
 import { applyRealtimeRoomNotification } from '@/lib/chat/realtimeRoomCache';
 import { clearRejoinedRoomUiOverride } from '@/lib/chat/rejoinedRoomUiCache';
-import { onForegroundMessage } from '@/lib/firebase/messaging';
 import { chatKeys } from '@/lib/hooks/chat/queryKeys';
 import { useChatRealtimeConnection } from '@/lib/hooks/chat/useChatRealtimeConnection';
 import { useChatSubscriptions } from '@/lib/hooks/chat/useChatSubscriptions';
@@ -92,16 +91,6 @@ export default function AppFrame({
 
   useChatRealtimeConnection({ enabled: isAuthed === true && currentUserId !== null });
   useFcmToken();
-
-  useEffect(() => {
-    if (isAuthed !== true) return;
-    const unsubscribe = onForegroundMessage((payload) => {
-      const p = payload as { notification?: { title?: string; body?: string } };
-      const body = p.notification?.body ?? p.notification?.title ?? '새 알림이 도착했습니다.';
-      toast(body);
-    });
-    return () => unsubscribe();
-  }, [isAuthed]);
 
   const handleChatUserNotification = useCallback(
     (frame: IMessage) => {

--- a/src/components/mypage/MyPageScreen.tsx
+++ b/src/components/mypage/MyPageScreen.tsx
@@ -77,7 +77,10 @@ export default function MyPageScreen() {
 
     setIsLoggingOut(true);
     try {
-      await unregisterFcmToken();
+      const isFcmUnregistered = await unregisterFcmToken();
+      if (!isFcmUnregistered) {
+        toast('푸시 알림 해제에 실패했지만 로그아웃은 계속 진행합니다.');
+      }
       const result = await postLogout();
       if (!result.ok) {
         throw new Error('로그아웃에 실패했습니다.');

--- a/src/components/mypage/MyPageScreen.tsx
+++ b/src/components/mypage/MyPageScreen.tsx
@@ -12,7 +12,10 @@ import EditProfileModal from '@/components/mypage/EditProfileModal';
 import WithdrawModal from '@/components/mypage/WithdrawModal';
 import { postLogout } from '@/lib/api/auth';
 import { clearAccessToken } from '@/lib/auth/token';
-import { unregisterFcmToken } from '@/lib/hooks/notifications/useFcmToken';
+import {
+  unregisterFcmToken,
+  usePushNotificationToggle,
+} from '@/lib/hooks/notifications/useFcmToken';
 import { useMeQuery } from '@/lib/hooks/users/useMeQuery';
 import { useMyCommentsInfiniteQuery } from '@/lib/hooks/users/useMyCommentsInfiniteQuery';
 import { useMyPostsInfiniteQuery } from '@/lib/hooks/users/useMyPostsInfiniteQuery';
@@ -47,6 +50,12 @@ export default function MyPageScreen() {
   const [isWithdrawOpen, setIsWithdrawOpen] = useState(false);
   const [isLogoutConfirmOpen, setIsLogoutConfirmOpen] = useState(false);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
+  const {
+    isActive: isPushActive,
+    isPending: isPushPending,
+    toggle: togglePush,
+    isSupported: isPushSupported,
+  } = usePushNotificationToggle();
 
   const handleWithdraw = () => {
     setIsEditOpen(false);
@@ -274,6 +283,27 @@ export default function MyPageScreen() {
                 </p>
               </button>
             </div>
+
+            {isPushSupported && (
+              <div className="flex items-center justify-between rounded-xl border border-neutral-200 bg-white px-4 py-3">
+                <div>
+                  <p className="text-sm font-semibold text-neutral-900">푸시 알림</p>
+                  <p className="text-xs text-neutral-500">새 알림을 푸시로 받습니다</p>
+                </div>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={isPushActive}
+                  onClick={() => void togglePush()}
+                  disabled={isPushPending}
+                  className={`relative h-6 w-11 rounded-full transition-colors disabled:opacity-50 ${isPushActive ? 'bg-[#05C075]' : 'bg-neutral-300'}`}
+                >
+                  <span
+                    className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform ${isPushActive ? 'translate-x-5' : 'translate-x-0'}`}
+                  />
+                </button>
+              </div>
+            )}
           </div>
         )}
       </section>

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -242,6 +242,9 @@ export const api = {
   put<T>(path: string, body?: unknown, opts?: Omit<RequestOptions, 'method' | 'path' | 'body'>) {
     return apiRequest<T>({ method: 'PUT', path, body, ...opts });
   },
+  patch<T>(path: string, body?: unknown, opts?: Omit<RequestOptions, 'method' | 'path' | 'body'>) {
+    return apiRequest<T>({ method: 'PATCH', path, body, ...opts });
+  },
   delete<T>(path: string, opts?: Omit<RequestOptions, 'method' | 'path'>) {
     return apiRequest<T>({ method: 'DELETE', path, ...opts });
   },

--- a/src/lib/api/notifications.ts
+++ b/src/lib/api/notifications.ts
@@ -45,7 +45,7 @@ export async function deleteFcmToken(deviceId: string): Promise<ApiClientResult<
 
 export async function patchFcmToken(
   deviceId: string,
-  body: { active: boolean },
+  body: { isActive: boolean },
 ): Promise<ApiClientResult<unknown>> {
   return api.patch(`/api/notifications/tokens/${encodeURIComponent(deviceId)}`, body);
 }

--- a/src/lib/api/notifications.ts
+++ b/src/lib/api/notifications.ts
@@ -42,3 +42,10 @@ export async function postFcmToken(
 export async function deleteFcmToken(deviceId: string): Promise<ApiClientResult<unknown>> {
   return api.delete(`/api/notifications/tokens/${encodeURIComponent(deviceId)}`);
 }
+
+export async function patchFcmToken(
+  deviceId: string,
+  body: { active: boolean },
+): Promise<ApiClientResult<unknown>> {
+  return api.patch(`/api/notifications/tokens/${encodeURIComponent(deviceId)}`, body);
+}

--- a/src/lib/hooks/notifications/useFcmToken.ts
+++ b/src/lib/hooks/notifications/useFcmToken.ts
@@ -43,7 +43,8 @@ export function useFcmToken() {
       if (!token) return;
 
       const deviceId = getOrCreateDeviceId();
-      await postFcmToken(deviceId, { token, deviceType: 'WEB' });
+      const postResult = await postFcmToken(deviceId, { token, deviceType: 'WEB' });
+      if (!postResult.ok) return;
       localStorage.setItem(PUSH_ACTIVE_KEY, 'true');
     };
 
@@ -71,7 +72,11 @@ export function usePushNotificationToggle() {
       if (isActive) {
         const deviceId = getStoredDeviceId();
         if (!deviceId) return;
-        await patchFcmToken(deviceId, { isActive: false });
+        const patchResult = await patchFcmToken(deviceId, { isActive: false });
+        if (!patchResult.ok) {
+          toast('알림 설정을 변경하지 못했어요. 잠시 후 다시 시도해 주세요.');
+          return;
+        }
         setIsActive(false);
         localStorage.setItem(PUSH_ACTIVE_KEY, 'false');
       } else {
@@ -84,10 +89,20 @@ export function usePushNotificationToggle() {
 
         const deviceId = getOrCreateDeviceId();
         const token = await requestFcmToken();
-        if (token) {
-          await postFcmToken(deviceId, { token, deviceType: 'WEB' });
+        if (!token) {
+          toast('푸시 토큰을 가져오지 못했어요. 잠시 후 다시 시도해 주세요.');
+          return;
         }
-        await patchFcmToken(deviceId, { isActive: true });
+        const postResult = await postFcmToken(deviceId, { token, deviceType: 'WEB' });
+        if (!postResult.ok) {
+          toast('알림을 켜지 못했어요. 잠시 후 다시 시도해 주세요.');
+          return;
+        }
+        const patchResult = await patchFcmToken(deviceId, { isActive: true });
+        if (!patchResult.ok) {
+          toast('알림을 켜지 못했어요. 잠시 후 다시 시도해 주세요.');
+          return;
+        }
         setIsActive(true);
         localStorage.setItem(PUSH_ACTIVE_KEY, 'true');
       }

--- a/src/lib/hooks/notifications/useFcmToken.ts
+++ b/src/lib/hooks/notifications/useFcmToken.ts
@@ -43,6 +43,7 @@ export function useFcmToken() {
 
       const deviceId = getOrCreateDeviceId();
       await postFcmToken(deviceId, { token, deviceType: 'WEB' });
+      localStorage.setItem(PUSH_ACTIVE_KEY, 'true');
     };
 
     void register();

--- a/src/lib/hooks/notifications/useFcmToken.ts
+++ b/src/lib/hooks/notifications/useFcmToken.ts
@@ -70,7 +70,7 @@ export function usePushNotificationToggle() {
       if (isActive) {
         const deviceId = getStoredDeviceId();
         if (!deviceId) return;
-        await patchFcmToken(deviceId, { active: false });
+        await patchFcmToken(deviceId, { isActive: false });
         setIsActive(false);
         localStorage.setItem(PUSH_ACTIVE_KEY, 'false');
       } else {
@@ -86,7 +86,7 @@ export function usePushNotificationToggle() {
         if (token) {
           await postFcmToken(deviceId, { token, deviceType: 'WEB' });
         }
-        await patchFcmToken(deviceId, { active: true });
+        await patchFcmToken(deviceId, { isActive: true });
         setIsActive(true);
         localStorage.setItem(PUSH_ACTIVE_KEY, 'true');
       }

--- a/src/lib/hooks/notifications/useFcmToken.ts
+++ b/src/lib/hooks/notifications/useFcmToken.ts
@@ -1,9 +1,11 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
-import { deleteFcmToken, postFcmToken } from '@/lib/api/notifications';
+import { deleteFcmToken, patchFcmToken, postFcmToken } from '@/lib/api/notifications';
 import { requestFcmToken } from '@/lib/firebase/messaging';
+import { toast } from '@/lib/toast/store';
 
 const DEVICE_ID_KEY = 'fcm_device_id';
+const PUSH_ACTIVE_KEY = 'fcm_notifications_active';
 
 function getOrCreateDeviceId(): string {
   let id = localStorage.getItem(DEVICE_ID_KEY);
@@ -45,4 +47,52 @@ export function useFcmToken() {
 
     void register();
   }, []);
+}
+
+export function usePushNotificationToggle() {
+  const [isActive, setIsActive] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    if (!('Notification' in window) || Notification.permission !== 'granted') return false;
+    const stored = localStorage.getItem(PUSH_ACTIVE_KEY);
+    return stored === null ? true : stored === 'true';
+  });
+  const [isPending, setIsPending] = useState(false);
+
+  const isSupported =
+    typeof window !== 'undefined' && 'Notification' in window && 'serviceWorker' in navigator;
+
+  const toggle = async () => {
+    if (isPending) return;
+
+    setIsPending(true);
+    try {
+      if (isActive) {
+        const deviceId = getStoredDeviceId();
+        if (!deviceId) return;
+        await patchFcmToken(deviceId, { active: false });
+        setIsActive(false);
+        localStorage.setItem(PUSH_ACTIVE_KEY, 'false');
+      } else {
+        if (Notification.permission !== 'granted') {
+          toast('브라우저 설정에서 알림 권한을 허용해 주세요.');
+          if (Notification.permission === 'denied') return;
+          const permission = await Notification.requestPermission();
+          if (permission !== 'granted') return;
+        }
+
+        const deviceId = getOrCreateDeviceId();
+        const token = await requestFcmToken();
+        if (token) {
+          await postFcmToken(deviceId, { token, deviceType: 'WEB' });
+        }
+        await patchFcmToken(deviceId, { active: true });
+        setIsActive(true);
+        localStorage.setItem(PUSH_ACTIVE_KEY, 'true');
+      }
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  return { isActive, isPending, toggle, isSupported };
 }

--- a/src/lib/hooks/notifications/useFcmToken.ts
+++ b/src/lib/hooks/notifications/useFcmToken.ts
@@ -33,6 +33,7 @@ export function useFcmToken() {
     if (!('Notification' in window)) return;
     if (!('serviceWorker' in navigator)) return;
     if (Notification.permission === 'denied') return;
+    if (localStorage.getItem(PUSH_ACTIVE_KEY) === 'false') return;
 
     const register = async () => {
       const permission = await Notification.requestPermission();

--- a/src/lib/hooks/notifications/useFcmToken.ts
+++ b/src/lib/hooks/notifications/useFcmToken.ts
@@ -21,10 +21,16 @@ export function getStoredDeviceId(): string | null {
   return localStorage.getItem(DEVICE_ID_KEY);
 }
 
-export async function unregisterFcmToken(): Promise<void> {
+export async function unregisterFcmToken(): Promise<boolean> {
   const deviceId = getStoredDeviceId();
-  if (!deviceId) return;
-  await deleteFcmToken(deviceId);
+  if (!deviceId) return true;
+
+  try {
+    const result = await deleteFcmToken(deviceId);
+    return result.ok || result.status === 404;
+  } catch {
+    return false;
+  }
 }
 
 export function useFcmToken() {
@@ -40,15 +46,23 @@ export function useFcmToken() {
       if (permission !== 'granted') return;
 
       const token = await requestFcmToken();
-      if (!token) return;
+      if (!token) {
+        toast('푸시 알림 등록에 실패했어요. 잠시 후 다시 시도해 주세요.');
+        return;
+      }
 
       const deviceId = getOrCreateDeviceId();
       const postResult = await postFcmToken(deviceId, { token, deviceType: 'WEB' });
-      if (!postResult.ok) return;
+      if (!postResult.ok) {
+        toast('푸시 알림 등록에 실패했어요. 잠시 후 다시 시도해 주세요.');
+        return;
+      }
       localStorage.setItem(PUSH_ACTIVE_KEY, 'true');
     };
 
-    void register();
+    void register().catch(() => {
+      toast('푸시 알림 등록에 실패했어요. 잠시 후 다시 시도해 주세요.');
+    });
   }, []);
 }
 
@@ -73,7 +87,7 @@ export function usePushNotificationToggle() {
         const deviceId = getStoredDeviceId();
         if (!deviceId) return;
         const patchResult = await patchFcmToken(deviceId, { isActive: false });
-        if (!patchResult.ok) {
+        if (!patchResult.ok && patchResult.status !== 404) {
           toast('알림 설정을 변경하지 못했어요. 잠시 후 다시 시도해 주세요.');
           return;
         }
@@ -95,11 +109,6 @@ export function usePushNotificationToggle() {
         }
         const postResult = await postFcmToken(deviceId, { token, deviceType: 'WEB' });
         if (!postResult.ok) {
-          toast('알림을 켜지 못했어요. 잠시 후 다시 시도해 주세요.');
-          return;
-        }
-        const patchResult = await patchFcmToken(deviceId, { isActive: true });
-        if (!patchResult.ok) {
           toast('알림을 켜지 못했어요. 잠시 후 다시 시도해 주세요.');
           return;
         }


### PR DESCRIPTION
## 📌 작업한 내용

  - api 클라이언트에 PATCH 메서드 추가 (src/lib/api/client.ts)
  - 알림 API에 patchFcmToken(deviceId, { isActive }) 추가 (src/lib/api/notifications.ts)
  - 마이페이지에 푸시 알림 토글 UI/동작 추가 (src/components/mypage/MyPageScreen.tsx)
  - useFcmToken 훅 리팩터링 및 토글 로직 추가 (src/lib/hooks/notifications/useFcmToken.ts)
  - 백엔드 FCM 계약 반영
  - PATCH 바디를 { isActive: boolean }로 고정
  - 푸시 ON 시 POST만 호출(중복 PATCH isActive:true 제거)
  - 푸시 OFF 시 PATCH isActive:false 호출
  - PUSH_ACTIVE_KEY === 'false'일 때 자동 재등록 차단
  - 실패 UX 보강
  - 자동 등록 실패 시 토스트 표시
  - 로그아웃 시 토큰 해제(DELETE) 실패를 감지하고 안내 토스트 표시
  - DELETE/PATCH의 404를 idempotent 성공으로 처리
  - AppFrame의 foreground FCM 토스트 구독 제거 (src/components/layout/AppFrame.tsx)

## 🔍 참고 사항

  - 백엔드 기준 엔드포인트/계약
  - POST /api/notifications/tokens/{deviceId}: { token, deviceType }
  - PATCH /api/notifications/tokens/{deviceId}: { isActive }
  - DELETE /api/notifications/tokens/{deviceId}

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
- [ ] (채팅) `/api/chatrooms` pagination에서 서버 cursor 재사용 원칙 준수 확인
