### PR TITLE
fix: 푸시 알림 토글 흐름 수정 및 백그라운드 알림 클릭 처리 추가

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -49,6 +49,6 @@ self.addEventListener('notificationclick', (event) => {
       });
       if (existing) return existing.focus();
       return clients.openWindow(url);
-    })
+    }),
   );
 });

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -15,9 +15,40 @@ const messaging = firebase.messaging();
 messaging.onBackgroundMessage((payload) => {
   const title = payload.notification?.title ?? '새 알림';
   const body = payload.notification?.body ?? '';
+  const targetPath = payload.data?.targetPath ?? '/';
 
   self.registration.showNotification(title, {
     body,
     icon: '/icons/icon-192x192.png',
+    data: { targetPath },
   });
+});
+
+function resolveTargetPath(targetPath) {
+  if (targetPath.startsWith('/ai/chat/')) {
+    const roomId = targetPath.replace('/ai/chat/', '').split('?')[0];
+    return `/llm/${roomId}?rid=${roomId}&from=notifications`;
+  }
+  return targetPath;
+}
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+
+  const rawPath = event.notification.data?.targetPath ?? '/';
+  const url = new URL(resolveTargetPath(rawPath), self.location.origin).href;
+
+  event.waitUntil(
+    clients.matchAll({ type: 'window', includeUncontrolled: true }).then((windowClients) => {
+      const existing = windowClients.find((c) => {
+        try {
+          return new URL(c.url).pathname === new URL(url).pathname && 'focus' in c;
+        } catch {
+          return false;
+        }
+      });
+      if (existing) return existing.focus();
+      return clients.openWindow(url);
+    })
+  );
 });

--- a/src/lib/hooks/notifications/useFcmToken.ts
+++ b/src/lib/hooks/notifications/useFcmToken.ts
@@ -71,7 +71,7 @@ export function usePushNotificationToggle() {
     if (typeof window === 'undefined') return false;
     if (!('Notification' in window) || Notification.permission !== 'granted') return false;
     const stored = localStorage.getItem(PUSH_ACTIVE_KEY);
-    return stored === null ? true : stored === 'true';
+    return stored === null ? false : stored === 'true';
   });
   const [isPending, setIsPending] = useState(false);
 
@@ -85,7 +85,10 @@ export function usePushNotificationToggle() {
     try {
       if (isActive) {
         const deviceId = getStoredDeviceId();
-        if (!deviceId) return;
+        if (!deviceId) {
+          toast('알림 설정을 변경하지 못했어요. 잠시 후 다시 시도해 주세요.');
+          return;
+        }
         const patchResult = await patchFcmToken(deviceId, { isActive: false });
         if (!patchResult.ok && patchResult.status !== 404) {
           toast('알림 설정을 변경하지 못했어요. 잠시 후 다시 시도해 주세요.');
@@ -94,26 +97,34 @@ export function usePushNotificationToggle() {
         setIsActive(false);
         localStorage.setItem(PUSH_ACTIVE_KEY, 'false');
       } else {
-        if (Notification.permission !== 'granted') {
-          toast('브라우저 설정에서 알림 권한을 허용해 주세요.');
-          if (Notification.permission === 'denied') return;
-          const permission = await Notification.requestPermission();
-          if (permission !== 'granted') return;
-        }
-
-        const deviceId = getOrCreateDeviceId();
-        const token = await requestFcmToken();
-        if (!token) {
-          toast('푸시 토큰을 가져오지 못했어요. 잠시 후 다시 시도해 주세요.');
-          return;
-        }
-        const postResult = await postFcmToken(deviceId, { token, deviceType: 'WEB' });
-        if (!postResult.ok) {
+        const deviceId = getStoredDeviceId();
+        if (!deviceId) {
           toast('알림을 켜지 못했어요. 잠시 후 다시 시도해 주세요.');
           return;
         }
-        setIsActive(true);
-        localStorage.setItem(PUSH_ACTIVE_KEY, 'true');
+        const patchResult = await patchFcmToken(deviceId, { isActive: true });
+        if (patchResult.ok) {
+          setIsActive(true);
+          localStorage.setItem(PUSH_ACTIVE_KEY, 'true');
+          return;
+        }
+        // 토큰 레코드가 삭제된 경우(404) 재등록 시도
+        if (patchResult.status === 404) {
+          const token = await requestFcmToken();
+          if (!token) {
+            toast('알림을 켜지 못했어요. 잠시 후 다시 시도해 주세요.');
+            return;
+          }
+          const postResult = await postFcmToken(deviceId, { token, deviceType: 'WEB' });
+          if (!postResult.ok) {
+            toast('알림을 켜지 못했어요. 잠시 후 다시 시도해 주세요.');
+            return;
+          }
+          setIsActive(true);
+          localStorage.setItem(PUSH_ACTIVE_KEY, 'true');
+          return;
+        }
+        toast('알림을 켜지 못했어요. 잠시 후 다시 시도해 주세요.');
       }
     } finally {
       setIsPending(false);


### PR DESCRIPTION
## 📌 작업한 내용

  푸시 알림 토글 흐름 및 백그라운드 알림 클릭 동작을 백엔드 API 계약에 맞게 수정했습니다.                                                                  
                                                                                 
  **토글 흐름 수정** (`useFcmToken.ts`)
  - 토글 ON 시 불필요한 FCM 토큰 재발급 제거 → `PATCH { isActive: true }` 사용   
  - `PATCH` 404 응답 시(백엔드 만료 토큰 자동 삭제 케이스) Firebase 토큰 재발급 후 `POST` 재등록 폴백 추가
  - `deviceId` 누락 시 조용히 실패하던 것을 에러 토스트로 처리
  - 미등록 상태(`PUSH_ACTIVE_KEY` 없음)에서 토글 초기값을 `true` → `false`로 변경 (등록 완료 전 "켜짐" 표시 방지)

  **백그라운드 알림 클릭 처리** (`firebase-messaging-sw.js`)
  - `notificationclick` 핸들러 추가 — 알림 클릭 시 `targetPath` 기반으로 페이지 이동
  - 백엔드 `/ai/chat/{id}` → 프론트 `/llm/{id}?rid={id}&from=notifications` 라우트 변환 적용
  - 동일 pathname의 탭이 이미 열려있으면 포커스, 없으면 새 탭으로 열기

## 🔍 참고 사항

  - 백엔드 `FcmService`가 만료 토큰을 자동 삭제(`UNREGISTERED` /
  `INVALID_ARGUMENT`)하는 케이스에서, 이후 토글 ON 시 `PATCH` 404가 반환됨 → 프론트에서 `POST` 재등록으로 폴백 처리

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
- [ ] (채팅) `/api/chatrooms` pagination에서 서버 cursor 재사용 원칙 준수 확인
