### PR TITLE
[#206] fix: iOS PWA에서 토글 ON 시 최초 등록 플로우 추가

### DIFF
--- a/src/lib/hooks/notifications/useFcmToken.ts
+++ b/src/lib/hooks/notifications/useFcmToken.ts
@@ -98,10 +98,30 @@ export function usePushNotificationToggle() {
         localStorage.setItem(PUSH_ACTIVE_KEY, 'false');
       } else {
         const deviceId = getStoredDeviceId();
+
+        // deviceId 없음 = 최초 등록 시도 (iOS PWA 등 앱 로드 시 권한 요청 실패 케이스)
         if (!deviceId) {
-          toast('알림을 켜지 못했어요. 잠시 후 다시 시도해 주세요.');
+          const permission = await Notification.requestPermission();
+          if (permission !== 'granted') {
+            toast('알림 권한을 허용해 주세요.');
+            return;
+          }
+          const token = await requestFcmToken();
+          if (!token) {
+            toast('알림을 켜지 못했어요. 잠시 후 다시 시도해 주세요.');
+            return;
+          }
+          const newDeviceId = getOrCreateDeviceId();
+          const postResult = await postFcmToken(newDeviceId, { token, deviceType: 'WEB' });
+          if (!postResult.ok) {
+            toast('알림을 켜지 못했어요. 잠시 후 다시 시도해 주세요.');
+            return;
+          }
+          setIsActive(true);
+          localStorage.setItem(PUSH_ACTIVE_KEY, 'true');
           return;
         }
+
         const patchResult = await patchFcmToken(deviceId, { isActive: true });
         if (patchResult.ok) {
           setIsActive(true);


### PR DESCRIPTION
## 📌 작업한 내용

  iOS PWA에서 푸시 알림 토글 ON 시 "알림을 켜지 못했어요" 토스트가 뜨는 버그를
  수정했습니다.                                                                           
                                                                                          
  **원인**
  iOS는 사용자 제스처(탭) 없이 알림 권한 요청(`Notification.requestPermission()`)이       
  동작하지 않습니다.
  앱 로드 시 `useFcmToken`이 권한 요청을 시도하지만 제스처 없이 호출되어 실패하고,
  결과적으로 `fcm_device_id`가 localStorage에 저장되지 않습니다.
  이후 사용자가 토글을 눌러 ON 시도 시 `deviceId`가 null이어서 즉시 에러 토스트를
  반환했습니다.

  **수정**
  토글 ON 시 `deviceId`가 없는 경우(최초 등록 실패 케이스) 에러 토스트 대신
  권한 요청 → FCM 토큰 발급 → POST 등록 플로우를 실행하도록 변경했습니다.
  토글 클릭 자체가 사용자 제스처이므로 iOS에서 권한 요청이 정상 동작합니다.

## 🔍 참고 사항

  - 변경 파일: `src/lib/hooks/notifications/useFcmToken.ts`
  - iOS PWA 푸시 알림은 **iOS 16.4 이상 + Safari로 홈 화면에 추가(PWA 설치)** 환경에서만 지원됩니다
  - Android Chrome은 기존과 동일하게 앱 로드 시 자동 등록됩니다

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

Ref #206 

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
- [ ] (채팅) `/api/chatrooms` pagination에서 서버 cursor 재사용 원칙 준수 확인
