### PR TITLE
fix: 모바일 입력창 자동 확대 방지를 위해 font-size text-base(16px)로 통일

### DIFF
--- a/src/components/board/detail/CommentComposer.tsx
+++ b/src/components/board/detail/CommentComposer.tsx
@@ -51,7 +51,7 @@ export default function CommentComposer({
         placeholder={placeholder}
         maxLength={maxLength}
         disabled={isSubmitting}
-        className="flex-1 rounded-full border border-neutral-200 bg-white px-4 py-2 text-xs text-neutral-700 placeholder:text-neutral-400 focus:border-[#05C075] focus:outline-none"
+        className="flex-1 rounded-full border border-neutral-200 bg-white px-4 py-2 text-base text-neutral-700 placeholder:text-neutral-400 focus:border-[#05C075] focus:outline-none"
         aria-label="댓글 입력"
       />
       {onCancel ? (

--- a/src/components/calendar/CalendarFilters.tsx
+++ b/src/components/calendar/CalendarFilters.tsx
@@ -90,7 +90,7 @@ export default function CalendarFilters({
           <div>
             <label className="mb-2 block text-xs font-medium text-[#8A8A8A]">태그</label>
             <input
-              className="w-full rounded-lg border border-[#E8E8E8] bg-white px-3 py-2 text-sm text-[#151515] placeholder:text-[#CCCCCC] focus:border-[#05C075] focus:outline-none"
+              className="w-full rounded-lg border border-[#E8E8E8] bg-white px-3 py-2 text-base text-[#151515] placeholder:text-[#CCCCCC] focus:border-[#05C075] focus:outline-none"
               type="text"
               placeholder="태그 입력..."
               value={tag}

--- a/src/components/calendar/EventFormModal.tsx
+++ b/src/components/calendar/EventFormModal.tsx
@@ -204,14 +204,14 @@ export default function EventFormModal({
   const labelClass = 'text-[11px] font-semibold text-black/60';
   const requiredMark = <span className="ml-1 text-[#05C075]">*</span>;
   const fieldClass =
-    'h-10 w-full rounded-2xl border border-black/10 bg-white px-3 text-sm text-black placeholder:text-black/30 focus:border-[#05C075] focus:outline-none focus:ring-2 focus:ring-[#05C075]/20';
+    'h-10 w-full rounded-2xl border border-black/10 bg-white px-3 text-base text-black placeholder:text-black/30 focus:border-[#05C075] focus:outline-none focus:ring-2 focus:ring-[#05C075]/20';
   const compactFieldClass =
-    'h-10 rounded-2xl border border-black/10 bg-white px-3 text-sm text-black focus:border-[#05C075] focus:outline-none focus:ring-2 focus:ring-[#05C075]/20';
+    'h-10 rounded-2xl border border-black/10 bg-white px-3 text-base text-black focus:border-[#05C075] focus:outline-none focus:ring-2 focus:ring-[#05C075]/20';
   const dateFieldClass = fieldClass;
   const tagFieldClass =
-    'h-10 w-full rounded-2xl border border-black/10 bg-white px-3 text-sm text-black placeholder:text-black/30 focus:border-[#05C075] focus:outline-none focus:ring-2 focus:ring-[#05C075]/20';
+    'h-10 w-full rounded-2xl border border-black/10 bg-white px-3 text-base text-black placeholder:text-black/30 focus:border-[#05C075] focus:outline-none focus:ring-2 focus:ring-[#05C075]/20';
   const textAreaClass =
-    'min-h-[80px] w-full rounded-2xl border border-black/10 bg-white px-3 py-2 text-sm text-black placeholder:text-black/30 focus:border-[#05C075] focus:outline-none focus:ring-2 focus:ring-[#05C075]/20';
+    'min-h-[80px] w-full rounded-2xl border border-black/10 bg-white px-3 py-2 text-base text-black placeholder:text-black/30 focus:border-[#05C075] focus:outline-none focus:ring-2 focus:ring-[#05C075]/20';
 
   return (
     <BaseModal

--- a/src/components/common/NicknameField.tsx
+++ b/src/components/common/NicknameField.tsx
@@ -27,7 +27,7 @@ export default function NicknameField({
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
           className={cn(
-            'h-12 w-full rounded-xl border px-4 text-sm outline-none',
+            'h-12 w-full rounded-xl border px-4 text-base outline-none',
             'bg-background placeholder:text-muted-foreground',
             'focus:ring-2',
             hasError

--- a/src/components/llm/analysis/LlmTextAreaCard.tsx
+++ b/src/components/llm/analysis/LlmTextAreaCard.tsx
@@ -55,7 +55,7 @@ export default function LlmTextAreaCard({
 
       <textarea
         className={[
-          'mt-4 min-h-[120px] w-full resize-none rounded-xl border border-neutral-200 bg-neutral-50 px-4 py-3.5 text-[15px] leading-6 font-medium text-neutral-900 transition outline-none placeholder:text-neutral-400 focus:border-[#05C075] focus:ring-2 focus:ring-[#05C075]/20',
+          'mt-4 min-h-[120px] w-full resize-none rounded-xl border border-neutral-200 bg-neutral-50 px-4 py-3.5 text-base leading-6 font-medium text-neutral-900 transition outline-none placeholder:text-neutral-400 focus:border-[#05C075] focus:ring-2 focus:ring-[#05C075]/20',
           textDisabled ? 'cursor-not-allowed opacity-50' : '',
         ].join(' ')}
         placeholder={

--- a/src/components/llm/chat/LlmComposer.tsx
+++ b/src/components/llm/chat/LlmComposer.tsx
@@ -119,7 +119,7 @@ export default function LlmComposer(props: Props) {
         <div className="flex-1" onMouseDown={handleDisabledInputClick}>
           <textarea
             className={[
-              'h-11 w-full resize-none rounded-2xl border border-neutral-200 bg-white px-3 py-2 text-sm font-medium text-neutral-900 transition outline-none placeholder:text-neutral-400 focus:border-[#05C075] focus:ring-2 focus:ring-[#05C075]/20',
+              'h-11 w-full resize-none rounded-2xl border border-neutral-200 bg-white px-3 py-2 text-base font-medium text-neutral-900 transition outline-none placeholder:text-neutral-400 focus:border-[#05C075] focus:ring-2 focus:ring-[#05C075]/20',
               disabled ? 'bg-neutral-100 text-neutral-400' : '',
             ].join(' ')}
             placeholder="메시지를 입력하세요"

--- a/src/components/mypage/WithdrawModal.tsx
+++ b/src/components/mypage/WithdrawModal.tsx
@@ -105,7 +105,7 @@ export default function WithdrawModal({ open, onClose, nickname }: WithdrawModal
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
           placeholder="위 문구를 입력하세요"
-          className="h-12 w-full rounded-xl border border-neutral-300 px-4 text-sm focus:border-neutral-900 focus:outline-none"
+          className="h-12 w-full rounded-xl border border-neutral-300 px-4 text-base focus:border-neutral-900 focus:outline-none"
         />
 
         {error && <p className="text-center text-xs text-red-500">{error}</p>}

--- a/src/components/todo/TodoCreateModal.tsx
+++ b/src/components/todo/TodoCreateModal.tsx
@@ -95,7 +95,7 @@ export default function TodoCreateModal({
             onChange={(event) => setTitle(event.target.value.slice(0, TODO_TITLE_MAX_LENGTH))}
             maxLength={TODO_TITLE_MAX_LENGTH}
             placeholder="할 일을 입력하세요"
-            className="h-12 w-full rounded-2xl border border-black/10 bg-white px-4 text-sm text-black placeholder:text-black/30 focus:border-black focus:ring-2 focus:ring-[#05C075]/20 focus:outline-none"
+            className="h-12 w-full rounded-2xl border border-black/10 bg-white px-4 text-base text-black placeholder:text-black/30 focus:border-black focus:ring-2 focus:ring-[#05C075]/20 focus:outline-none"
           />
           <div className="mt-1 text-right text-[11px] text-black/40">
             {title.length}/{TODO_TITLE_MAX_LENGTH}
@@ -108,7 +108,7 @@ export default function TodoCreateModal({
             type="date"
             value={dueDate}
             onChange={(event) => setDueDate(event.target.value as LocalDateString)}
-            className="h-12 w-full rounded-2xl border border-black/10 bg-white px-4 text-sm text-black/80 focus:border-black focus:ring-2 focus:ring-[#05C075]/20 focus:outline-none"
+            className="h-12 w-full rounded-2xl border border-black/10 bg-white px-4 text-base text-black/80 focus:border-black focus:ring-2 focus:ring-[#05C075]/20 focus:outline-none"
           />
         </div>
 

--- a/src/components/todo/TodoEditModal.tsx
+++ b/src/components/todo/TodoEditModal.tsx
@@ -85,7 +85,7 @@ export default function TodoEditModal({ open, onClose, todo, onSubmit }: TodoEdi
             value={title}
             onChange={(event) => setTitle(event.target.value)}
             placeholder="할 일을 입력하세요"
-            className="h-12 w-full rounded-xl border border-neutral-300 px-4 text-sm focus:border-neutral-900 focus:outline-none"
+            className="h-12 w-full rounded-xl border border-neutral-300 px-4 text-base focus:border-neutral-900 focus:outline-none"
           />
         </div>
 
@@ -95,7 +95,7 @@ export default function TodoEditModal({ open, onClose, todo, onSubmit }: TodoEdi
             type="date"
             value={dueDate}
             onChange={(event) => setDueDate(event.target.value as LocalDateString)}
-            className="h-12 w-full rounded-xl border border-neutral-300 px-4 text-sm focus:border-neutral-900 focus:outline-none"
+            className="h-12 w-full rounded-xl border border-neutral-300 px-4 text-base focus:border-neutral-900 focus:outline-none"
           />
         </div>
 

--- a/src/screens/board/BoardSearchPage.tsx
+++ b/src/screens/board/BoardSearchPage.tsx
@@ -279,7 +279,7 @@ export default function BoardSearchPage() {
                 onFocus={() => setIsSearchInputActive(true)}
                 onClick={() => setIsSearchInputActive(true)}
                 onChange={(event) => handleKeywordChange(event.target.value)}
-                className="h-10 w-full rounded-xl border border-neutral-200 bg-white pr-3 pl-9 text-sm text-neutral-900 transition outline-none focus:border-emerald-500"
+                className="h-10 w-full rounded-xl border border-neutral-200 bg-white pr-3 pl-9 text-base text-neutral-900 transition outline-none focus:border-emerald-500"
               />
             </div>
             <button

--- a/src/screens/chat/ChatCreatePage.tsx
+++ b/src/screens/chat/ChatCreatePage.tsx
@@ -229,7 +229,7 @@ export default function ChatCreatePage() {
               value={inputValue}
               onChange={(event) => setInputValue(event.target.value)}
               placeholder="이름을 입력하세요"
-              className="h-6 w-full border-0 bg-transparent text-sm text-[#191F28] outline-none placeholder:text-[#8B95A1]"
+              className="h-6 w-full border-0 bg-transparent text-base text-[#191F28] outline-none placeholder:text-[#8B95A1]"
               maxLength={MAX_NICKNAME_LENGTH}
             />
             <button

--- a/src/screens/chat/ChatRoomPage.tsx
+++ b/src/screens/chat/ChatRoomPage.tsx
@@ -922,7 +922,7 @@ export default function ChatRoomPage({ roomId, mode = 'room' }: ChatRoomPageProp
               value={messageInput}
               onChange={(event) => setMessageInput(event.target.value.slice(0, 2000))}
               placeholder="메시지를 입력하세요"
-              className="h-11 w-full resize-none rounded-2xl border border-neutral-200 bg-white px-3 py-2 text-sm font-medium text-neutral-900 transition outline-none placeholder:text-neutral-400 focus:border-[#05C075] focus:ring-2 focus:ring-[#05C075]/20"
+              className="h-11 w-full resize-none rounded-2xl border border-neutral-200 bg-white px-3 py-2 text-base font-medium text-neutral-900 transition outline-none placeholder:text-neutral-400 focus:border-[#05C075] focus:ring-2 focus:ring-[#05C075]/20"
               maxLength={2000}
               rows={1}
               onCompositionStart={() => {
@@ -1105,7 +1105,7 @@ export default function ChatRoomPage({ roomId, mode = 'room' }: ChatRoomPageProp
                             ? '1:1 채팅방은 이름 수정이 불가합니다.'
                             : '채팅방 이름을 입력하세요'
                         }
-                        className="h-10 w-full rounded-lg border border-neutral-200 px-3 text-sm text-neutral-900 placeholder:text-neutral-400 disabled:bg-neutral-100 disabled:text-neutral-400"
+                        className="h-10 w-full rounded-lg border border-neutral-200 px-3 text-base text-neutral-900 placeholder:text-neutral-400 disabled:bg-neutral-100 disabled:text-neutral-400"
                       />
                     </div>
                   </section>


### PR DESCRIPTION
## 📌 작업한 내용

  모바일 환경에서 입력창 탭 시 화면이 자동으로 확대되는 현상을 수정했습니다.

  iOS/Android 브라우저는 font-size < 16px인 입력창에 포커스 시 자동 줌을 적용합니다. 전체 
  입력창(input/textarea)의 font-size를 text-base(16px)로 통일해 이 동작을 방지했습니다.
                                                                                          
  수정 파일 (12개)
  - CommentComposer, NicknameField, LlmComposer, LlmTextAreaCard
  - TodoCreateModal, TodoEditModal, CalendarFilters, EventFormModal
  - WithdrawModal, BoardSearchPage, ChatCreatePage, ChatRoomPage

## 🔍 참고 사항

  - 변경 내용은 font-size만 조정하며, 레이아웃·디자인에 실질적인 영향은 없습니다.
  - 전역 CSS로 처리할 경우 Tailwind 유틸리티 클래스에 의해 덮어씌워지기 때문에 컴포넌트별로 수정했습니다.

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
- [ ] (채팅) `/api/chatrooms` pagination에서 서버 cursor 재사용 원칙 준수 확인
