### PR TITLE
perf: Lighthouse 기반 초기 로드 성능 최적화

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,11 @@
     "vitest": "^4.0.17"
   },
   "browserslist": [
-    "defaults and fully supports es6-module"
+    "chrome >= 92",
+    "firefox >= 90",
+    "safari >= 15.4",
+    "edge >= 92",
+    "not dead"
   ],
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/src/app/(app)/calendar/layout.tsx
+++ b/src/app/(app)/calendar/layout.tsx
@@ -1,5 +1,3 @@
-import '@/styles/fullcalendar.css';
-
 import type { ReactNode } from 'react';
 
 export default function CalendarLayout({ children }: { children: ReactNode }) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -58,9 +58,9 @@ export default function RootLayout({
           <>
             <Script
               src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
-              strategy="afterInteractive"
+              strategy="lazyOnload"
             />
-            <Script id="ga-init" strategy="afterInteractive">
+            <Script id="ga-init" strategy="lazyOnload">
               {`window.dataLayer = window.dataLayer || [];
 function gtag(){dataLayer.push(arguments);}
 gtag('js', new Date());

--- a/src/components/board/BoardPostCard.tsx
+++ b/src/components/board/BoardPostCard.tsx
@@ -73,6 +73,13 @@ export default function BoardPostCard({
             </button>
             <span className="text-xs text-neutral-400">{formatRelativeTime(post.createdAt)}</span>
           </div>
+          {post.author.interests && post.author.interests.length > 0 ? (
+            <div className="mt-0.5 flex flex-wrap gap-1 text-[11px] text-neutral-400">
+              {post.author.interests.map((interest) => (
+                <span key={interest}>#{interest}</span>
+              ))}
+            </div>
+          ) : null}
         </div>
       </div>
 
@@ -90,14 +97,6 @@ export default function BoardPostCard({
             >
               {tag}
             </span>
-          ))}
-        </div>
-      ) : null}
-
-      {post.author.interests && post.author.interests.length > 0 ? (
-        <div className="mt-2 flex flex-wrap gap-1 text-[11px] text-neutral-400">
-          {post.author.interests.map((interest) => (
-            <span key={interest}>#{interest}</span>
           ))}
         </div>
       ) : null}

--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import '@/styles/fullcalendar.css';
+
 import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin from '@fullcalendar/interaction';
 import FullCalendar from '@fullcalendar/react';

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { Bell, ChevronLeft, PersonStanding } from 'lucide-react';
-import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 
@@ -92,13 +91,14 @@ export default function Header({
               className="inline-flex items-center rounded-md transition hover:opacity-80"
               aria-label="Devths 홈 이동"
             >
-              <Image
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
                 src="/icons/Devths.svg"
                 alt="Devths"
                 width={156}
                 height={48}
                 className="h-12 w-auto"
-                priority
+                fetchPriority="high"
               />
             </button>
           ) : title ? (


### PR DESCRIPTION
## 📌 작업한 내용

  Lighthouse 기반 프론트엔드 성능 최적화 작업입니다.
                                                                                                         
  - **레거시 폴리필 제거**: `browserslist`를 Chrome 92+/Firefox 90+/Safari 15.4+ 기준으로 변경해 `Array.prototype.at`, `Object.hasOwn` 등 불필요한 폴리필 8종 제거 (JS 약 14KiB 절감)
  - **렌더링 차단 CSS 제거**: `fullcalendar.css` import를 `calendar/layout.tsx`에서 `CalendarView.tsx`(dynamic import)로 이동해 `/board` 등 타 페이지의 렌더링 차단 120ms 제거
  - **LCP 최적화**: Devths 로고 이미지를 `<img fetchPriority="high">`로 교체해 LCP 요소 우선 로드
  - **GA 로딩 지연**: GA 스크립트 전략을 `afterInteractive` → `lazyOnload`로 변경해 초기 렌더링 이후 유휴 시점에 로드 (GA 146KiB 지연 로드)

## 🔍 참고 사항

  - `fullcalendar.css`는 `CalendarView`가 `dynamic()`으로 지연 로드되므로 `/calendar` 진입 시에만 로드됩니다.
  - `images.unoptimized: true` 설정으로 인해 Next.js `<Image priority>`가 `fetchpriority="high"`를 삽입하지 못해 일반 `<img>` 태그로 교체했습니다.
  - GA `lazyOnload` 변경으로 페이지 초기 진입 직후의 GA 이벤트 수집 타이밍이 다소 늦어질 수 있습니다.

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
- [ ] (채팅) `/api/chatrooms` pagination에서 서버 cursor 재사용 원칙 준수 확인
