### PR TITLE
perf: 이미지 최적화 및 주요 페이지 SSR 적용으로 LCP 개선

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,7 +11,12 @@ const nextConfig: NextConfig = {
   devIndicators: false,
   output: 'standalone', // Docker 환경에서 경량 이미지 생성
   images: {
-    unoptimized: true, // SSR 환경에서 이미지 최적화 비활성화
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '**.amazonaws.com',
+      },
+    ],
   },
 };
 

--- a/src/app/(app)/board/[postId]/page.tsx
+++ b/src/app/(app)/board/[postId]/page.tsx
@@ -1,5 +1,24 @@
+import { QueryClient, HydrationBoundary, dehydrate } from '@tanstack/react-query';
+
+import { prefetchBoardDetail } from '@/lib/api/serverBoardPrefetch';
 import BoardDetailPage from '@/screens/board/detail/BoardDetailPage';
 
-export default function Page() {
-  return <BoardDetailPage />;
+type Props = {
+  params: Promise<{ postId: string }>;
+};
+
+export default async function Page({ params }: Props) {
+  const { postId: postIdStr } = await params;
+  const postId = Number(postIdStr);
+
+  const queryClient = new QueryClient();
+  if (Number.isInteger(postId) && postId > 0) {
+    await prefetchBoardDetail(queryClient, postId);
+  }
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <BoardDetailPage />
+    </HydrationBoundary>
+  );
 }

--- a/src/app/(app)/board/page.tsx
+++ b/src/app/(app)/board/page.tsx
@@ -1,5 +1,15 @@
+import { QueryClient, HydrationBoundary, dehydrate } from '@tanstack/react-query';
+
+import { prefetchBoardPosts } from '@/lib/api/serverBoardPrefetch';
 import BoardListPage from '@/screens/board/BoardListPage';
 
-export default function Page() {
-  return <BoardListPage />;
+export default async function Page() {
+  const queryClient = new QueryClient();
+  await prefetchBoardPosts(queryClient);
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <BoardListPage />
+    </HydrationBoundary>
+  );
 }

--- a/src/app/(app)/llm/page.tsx
+++ b/src/app/(app)/llm/page.tsx
@@ -1,5 +1,15 @@
+import { QueryClient, HydrationBoundary, dehydrate } from '@tanstack/react-query';
+
+import { prefetchLlmRooms } from '@/lib/api/serverLlmPrefetch';
 import LlmRoomsPage from '@/screens/llm/LlmRoomsPage';
 
-export default function Page() {
-  return <LlmRoomsPage />;
+export default async function Page() {
+  const queryClient = new QueryClient();
+  await prefetchLlmRooms(queryClient);
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <LlmRoomsPage />
+    </HydrationBoundary>
+  );
 }

--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -1,5 +1,15 @@
+import { QueryClient, HydrationBoundary, dehydrate } from '@tanstack/react-query';
+
+import { prefetchProfile } from '@/lib/api/serverProfilePrefetch';
 import MyPageScreen from '@/components/mypage/MyPageScreen';
 
-export default function ProfilePage() {
-  return <MyPageScreen />;
+export default async function ProfilePage() {
+  const queryClient = new QueryClient();
+  await prefetchProfile(queryClient);
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <MyPageScreen />
+    </HydrationBoundary>
+  );
 }

--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, HydrationBoundary, dehydrate } from '@tanstack/react-query';
 
-import { prefetchProfile } from '@/lib/api/serverProfilePrefetch';
 import MyPageScreen from '@/components/mypage/MyPageScreen';
+import { prefetchProfile } from '@/lib/api/serverProfilePrefetch';
 
 export default async function ProfilePage() {
   const queryClient = new QueryClient();

--- a/src/lib/api/serverBoardPrefetch.ts
+++ b/src/lib/api/serverBoardPrefetch.ts
@@ -1,0 +1,115 @@
+import { QueryClient } from '@tanstack/react-query';
+import { cookies } from 'next/headers';
+
+import { BOARD_PAGE_SIZE } from '@/constants/board';
+import { boardsKeys } from '@/lib/hooks/boards/queryKeys';
+
+import type { BoardInterest, BoardPostSummary, BoardSort, BoardTag } from '@/types/board';
+import type { CursorPage } from '@/types/pagination';
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+async function getServerAccessToken(cookieHeader: string): Promise<string | null> {
+  if (!BASE_URL) return null;
+  try {
+    const res = await fetch(new URL('/api/auth/tokens', BASE_URL).toString(), {
+      method: 'POST',
+      headers: { Cookie: cookieHeader },
+      cache: 'no-store',
+    });
+    if (!res.ok) return null;
+    const authHeader = res.headers.get('authorization');
+    return authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchBoardPostsServer(
+  token: string,
+  pageParam?: number,
+): Promise<CursorPage<BoardPostSummary>> {
+  const url = new URL('/api/posts', BASE_URL);
+  url.searchParams.set('size', String(BOARD_PAGE_SIZE));
+  if (pageParam !== undefined && pageParam !== null) {
+    url.searchParams.set('lastId', String(pageParam));
+  }
+
+  const res = await fetch(url.toString(), {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: 'no-store',
+  });
+
+  if (!res.ok) throw new Error('Failed to fetch posts');
+
+  const json = (await res.json()) as {
+    data?: {
+      posts: Array<{
+        postId: number;
+        title: string;
+        previewContent: string;
+        user: {
+          userId: number;
+          nickname: string;
+          profileImage: string | null;
+          interests: string[];
+        };
+        likeCount: number;
+        commentCount: number;
+        shareCount: number;
+        tags: string[];
+        createdAt: string;
+      }>;
+      lastId: number | null;
+      hasNext: boolean;
+    };
+  };
+
+  const data = json.data;
+  if (!data) throw new Error('Invalid response format');
+
+  return {
+    items: data.posts.map((post) => ({
+      postId: post.postId,
+      title: post.title,
+      preview: post.previewContent ?? '',
+      tags: post.tags as BoardTag[],
+      createdAt: post.createdAt,
+      author: {
+        userId: post.user.userId,
+        nickname: post.user.nickname,
+        profileImageUrl: post.user.profileImage ?? null,
+        interests: post.user.interests as BoardInterest[],
+      },
+      stats: {
+        likeCount: post.likeCount,
+        commentCount: post.commentCount,
+        shareCount: post.shareCount,
+      },
+    })) as BoardPostSummary[],
+    lastId: data.lastId ?? null,
+    hasNext: data.hasNext,
+  };
+}
+
+export async function prefetchBoardPosts(queryClient: QueryClient): Promise<void> {
+  const cookieStore = await cookies();
+  const cookieHeader = cookieStore
+    .getAll()
+    .map((c) => `${c.name}=${c.value}`)
+    .join('; ');
+
+  const token = await getServerAccessToken(cookieHeader);
+  if (!token || !BASE_URL) return;
+
+  const params = { size: BOARD_PAGE_SIZE, sort: 'LATEST' as BoardSort, tags: [] as BoardTag[] };
+
+  await queryClient.prefetchInfiniteQuery({
+    queryKey: boardsKeys.list(params),
+    queryFn: ({ pageParam }) => fetchBoardPostsServer(token, pageParam as number | undefined),
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage: CursorPage<BoardPostSummary>) =>
+      lastPage.hasNext ? (lastPage.lastId ?? undefined) : undefined,
+    pages: 1,
+  });
+}

--- a/src/lib/api/serverBoardPrefetch.ts
+++ b/src/lib/api/serverBoardPrefetch.ts
@@ -5,6 +5,7 @@ import { BOARD_PAGE_SIZE } from '@/constants/board';
 import { boardsKeys } from '@/lib/hooks/boards/queryKeys';
 
 import type { BoardInterest, BoardPostSummary, BoardSort, BoardTag } from '@/types/board';
+import type { CommentItem, PostDetail } from '@/types/boardDetail';
 import type { CursorPage } from '@/types/pagination';
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
@@ -90,6 +91,124 @@ async function fetchBoardPostsServer(
     lastId: data.lastId ?? null,
     hasNext: data.hasNext,
   };
+}
+
+async function fetchBoardDetailServer(token: string, postId: number): Promise<PostDetail> {
+  const res = await fetch(new URL(`/api/posts/${postId}`, BASE_URL).toString(), {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: 'no-store',
+  });
+  if (!res.ok) throw new Error('Failed to fetch post detail');
+
+  const json = (await res.json()) as {
+    data?: {
+      postId: number;
+      title: string;
+      content: string;
+      attachments: PostDetail['attachments'];
+      user: { userId: number; nickname: string; profileImage: string | null; interests: string[] };
+      likeCount: number;
+      commentCount: number;
+      shareCount: number;
+      tags: BoardTag[];
+      createdAt: string;
+      updatedAt: string;
+      isLiked: boolean;
+    };
+  };
+
+  const d = json.data;
+  if (!d) throw new Error('Invalid response format');
+
+  return {
+    postId: d.postId,
+    title: d.title,
+    content: d.content,
+    attachments: d.attachments,
+    author: {
+      userId: d.user.userId,
+      nickname: d.user.nickname,
+      profileImageUrl: d.user.profileImage ?? null,
+      interests: d.user.interests as BoardInterest[],
+    },
+    stats: { likeCount: d.likeCount, commentCount: d.commentCount, shareCount: d.shareCount },
+    tags: d.tags,
+    createdAt: d.createdAt,
+    updatedAt: d.updatedAt,
+    isLiked: d.isLiked,
+  };
+}
+
+async function fetchBoardCommentsServer(
+  token: string,
+  postId: number,
+  size = 50,
+): Promise<CursorPage<CommentItem>> {
+  const url = new URL(`/api/posts/${postId}/comments`, BASE_URL);
+  url.searchParams.set('size', String(size));
+
+  const res = await fetch(url.toString(), {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: 'no-store',
+  });
+  if (!res.ok) throw new Error('Failed to fetch comments');
+
+  const json = (await res.json()) as {
+    data?: {
+      comments: Array<{
+        commentId: number;
+        parentId: number | null;
+        content: string | null;
+        user: { userId: number; nickname: string; profileImage: string | null };
+        createdAt: string;
+        isDeleted: boolean;
+      }>;
+      lastId: number | null;
+      hasNext: boolean;
+    };
+  };
+
+  const d = json.data;
+  if (!d) throw new Error('Invalid response format');
+
+  return {
+    items: d.comments.map((c) => ({
+      commentId: c.commentId,
+      parentId: c.parentId ?? null,
+      content: c.content ?? null,
+      author: {
+        userId: c.user.userId,
+        nickname: c.user.nickname,
+        profileImageUrl: c.user.profileImage ?? null,
+      },
+      createdAt: c.createdAt,
+      isDeleted: c.isDeleted,
+    })),
+    lastId: d.lastId ?? null,
+    hasNext: d.hasNext,
+  };
+}
+
+export async function prefetchBoardDetail(queryClient: QueryClient, postId: number): Promise<void> {
+  const cookieStore = await cookies();
+  const cookieHeader = cookieStore
+    .getAll()
+    .map((c) => `${c.name}=${c.value}`)
+    .join('; ');
+
+  const token = await getServerAccessToken(cookieHeader);
+  if (!token || !BASE_URL) return;
+
+  await Promise.all([
+    queryClient.prefetchQuery({
+      queryKey: boardsKeys.detail(postId),
+      queryFn: () => fetchBoardDetailServer(token, postId),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: boardsKeys.comments(postId, 50),
+      queryFn: () => fetchBoardCommentsServer(token, postId),
+    }),
+  ]);
 }
 
 export async function prefetchBoardPosts(queryClient: QueryClient): Promise<void> {

--- a/src/lib/api/serverLlmPrefetch.ts
+++ b/src/lib/api/serverLlmPrefetch.ts
@@ -1,0 +1,75 @@
+import { QueryClient } from '@tanstack/react-query';
+import { cookies } from 'next/headers';
+
+import { llmKeys } from '@/lib/hooks/llm/queryKeys';
+
+import type { AiChatRoom } from '@/types/llm';
+import type { CursorListResponse } from '@/types/pagination';
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+async function getServerAccessToken(cookieHeader: string): Promise<string | null> {
+  if (!BASE_URL) return null;
+  try {
+    const res = await fetch(new URL('/api/auth/tokens', BASE_URL).toString(), {
+      method: 'POST',
+      headers: { Cookie: cookieHeader },
+      cache: 'no-store',
+    });
+    if (!res.ok) return null;
+    const authHeader = res.headers.get('authorization');
+    return authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  } catch {
+    return null;
+  }
+}
+
+type LlmRoomsPage = {
+  rooms: AiChatRoom[];
+  lastId: number | null;
+  hasNext: boolean;
+};
+
+export async function prefetchLlmRooms(queryClient: QueryClient): Promise<void> {
+  const cookieStore = await cookies();
+  const cookieHeader = cookieStore
+    .getAll()
+    .map((c) => `${c.name}=${c.value}`)
+    .join('; ');
+
+  const token = await getServerAccessToken(cookieHeader);
+  if (!token || !BASE_URL) return;
+
+  await queryClient.prefetchInfiniteQuery({
+    queryKey: llmKeys.rooms(),
+    queryFn: async ({ pageParam }) => {
+      const url = new URL('/api/ai-chatrooms', BASE_URL);
+      url.searchParams.set('size', '10');
+      if (pageParam !== undefined) {
+        url.searchParams.set('lastId', String(pageParam));
+      }
+
+      const res = await fetch(url.toString(), {
+        headers: { Authorization: `Bearer ${token}` },
+        cache: 'no-store',
+      });
+      if (!res.ok) throw new Error('Failed to fetch LLM rooms');
+
+      const json = (await res.json()) as {
+        data?: CursorListResponse<AiChatRoom, 'rooms'>;
+      };
+      const data = json.data;
+      if (!data) throw new Error('Invalid response format');
+
+      return {
+        rooms: data.rooms,
+        lastId: data.lastId ?? null,
+        hasNext: data.hasNext,
+      } as LlmRoomsPage;
+    },
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage: LlmRoomsPage) =>
+      lastPage.hasNext ? (lastPage.lastId ?? undefined) : undefined,
+    pages: 1,
+  });
+}

--- a/src/lib/api/serverProfilePrefetch.ts
+++ b/src/lib/api/serverProfilePrefetch.ts
@@ -1,0 +1,83 @@
+import { QueryClient } from '@tanstack/react-query';
+import { cookies } from 'next/headers';
+
+import { userKeys } from '@/lib/hooks/users/queryKeys';
+
+import type { MeData, MyPostSummaryData } from '@/lib/api/users';
+import type { CursorListResponse } from '@/types/pagination';
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+async function getServerAccessToken(cookieHeader: string): Promise<string | null> {
+  if (!BASE_URL) return null;
+  try {
+    const res = await fetch(new URL('/api/auth/tokens', BASE_URL).toString(), {
+      method: 'POST',
+      headers: { Cookie: cookieHeader },
+      cache: 'no-store',
+    });
+    if (!res.ok) return null;
+    const authHeader = res.headers.get('authorization');
+    return authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  } catch {
+    return null;
+  }
+}
+
+type MyPostsPage = {
+  posts: MyPostSummaryData[];
+  lastId: number | null;
+  hasNext: boolean;
+};
+
+export async function prefetchProfile(queryClient: QueryClient): Promise<void> {
+  const cookieStore = await cookies();
+  const cookieHeader = cookieStore
+    .getAll()
+    .map((c) => `${c.name}=${c.value}`)
+    .join('; ');
+
+  const token = await getServerAccessToken(cookieHeader);
+  if (!token || !BASE_URL) return;
+
+  const headers = { Authorization: `Bearer ${token}` };
+
+  await Promise.all([
+    queryClient.prefetchQuery({
+      queryKey: userKeys.me(),
+      queryFn: async () => {
+        const res = await fetch(new URL('/api/users/me', BASE_URL).toString(), {
+          headers,
+          cache: 'no-store',
+        });
+        if (!res.ok) throw new Error('Failed to fetch me');
+        const json = (await res.json()) as { data?: MeData };
+        if (!json.data) throw new Error('Invalid response format');
+        return json.data;
+      },
+    }),
+    queryClient.prefetchInfiniteQuery({
+      queryKey: userKeys.myPosts({ size: 5 }),
+      queryFn: async ({ pageParam }) => {
+        const url = new URL('/api/users/me/posts', BASE_URL);
+        url.searchParams.set('size', '5');
+        if (pageParam !== undefined) url.searchParams.set('lastId', String(pageParam));
+        const res = await fetch(url.toString(), { headers, cache: 'no-store' });
+        if (!res.ok) throw new Error('Failed to fetch my posts');
+        const json = (await res.json()) as {
+          data?: CursorListResponse<MyPostSummaryData, 'posts'>;
+        };
+        if (!json.data) throw new Error('Invalid response format');
+        return {
+          posts: json.data.posts,
+          lastId: json.data.lastId ?? null,
+          hasNext: json.data.hasNext,
+        } as MyPostsPage;
+      },
+      initialPageParam: undefined as number | undefined,
+      getNextPageParam: (lastPage: MyPostsPage) =>
+        lastPage.hasNext ? (lastPage.lastId ?? undefined) : undefined,
+      pages: 1,
+    }),
+  ]);
+}


### PR DESCRIPTION
## 📌 작업한 내용

## 성능 최적화 및 SSR 적용

### perf: Next.js 이미지 최적화 활성화

- `next.config.ts`에서 `images.unoptimized: true` 제거
- S3 도메인(`*.amazonaws.com`)을 `remotePatterns`에 추가
- `/_next/image`를 통한 자동 리사이즈 및 WebP 변환 적용
- 이미지 전송량을 대폭 줄여 로딩 성능 개선

### feat: 주요 페이지 SSR 적용 (TanStack Query `HydrationBoundary`)

서버에서 액세스 토큰을 직접 발급한 뒤 데이터를 `prefetch`하여 HTML에 포함함으로써 초기 렌더링 속도를 개선했습니다.

| 페이지 | 적용 내용 |
|---|---|
| `/board` | 게시글 목록 첫 페이지 즉시 렌더링 |
| `/board/[postId]` | 게시글 상세 + 댓글 즉시 렌더링 |
| `/llm` | 대화방 목록 첫 페이지 즉시 렌더링 |
| `/profile` | 내 정보 + 내 게시글 즉시 렌더링 |

## 🔍 참고 사항

  - 기존 프로젝트는 전체 CSR 구조였으나, output: 'standalone' 배포 방식과 무관하게 SSR 적용 가능
  - 액세스 토큰이 localStorage에 저장되어 있어, 서버에서 리프레시 토큰 쿠키를 forwarding하여 새 액세스
  토큰을 발급한 뒤 데이터 fetch하는 방식 사용
  - 클라이언트 측 TanStack Query 캐시와 충돌 없음 (HydrationBoundary가 서버 상태를 주입)
  - /calendar 페이지는 page.tsx가 'use client'이고 TanStack Query를 사용하지 않아 SSR 미적용

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
- [ ] (채팅) `/api/chatrooms` pagination에서 서버 cursor 재사용 원칙 준수 확인
