### PR TITLE
fix: LCP 개선 - isAuthed 낙관적 초기화 및 게시글 SSR 캐싱 적용

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -62,7 +62,6 @@ export default function RootLayout({
     <html lang="en">
       <head>
         <link rel="preload" href="/icons/Devths2.png" as="image" type="image/png" />
-        <link rel="preload" href="/images/background.webp" as="image" type="image/webp" />
         <link rel="preconnect" href="https://devths-storage-prod.s3.ap-northeast-2.amazonaws.com" />
         {API_ORIGIN ? <link rel="preconnect" href={API_ORIGIN} /> : null}
         <meta name="theme-color" content="#3AB569" />

--- a/src/components/layout/AppFrame.tsx
+++ b/src/components/layout/AppFrame.tsx
@@ -82,7 +82,7 @@ export default function AppFrame({
   const defaultFrameOptions = useMemo<AppFrameOptions>(() => ({ showBottomNav: true }), []);
   const [frameOptions, setFrameOptions] = useState<AppFrameOptions>(defaultFrameOptions);
   const isBottomNavVisible = true;
-  const [isAuthed, setIsAuthed] = useState<boolean | null>(null);
+  const [isAuthed, setIsAuthed] = useState<boolean | null>(true);
   const [isNavigationBlocked, setIsNavigationBlocked] = useState(false);
   const [blockMessage, setBlockMessage] = useState('');
   const [blockedNavigationHandler, setBlockedNavigationHandler] = useState<
@@ -263,17 +263,13 @@ export default function AppFrame({
                 accessibilityActive={options.accessibilityActive}
                 onAccessibilityClick={options.onAccessibilityClick}
               />
-              {isAuthed === true ? (
+              {isAuthed !== false ? (
                 <div
                   key={pathname}
                   className="page-enter px-4 pb-[var(--bottom-nav-h)] sm:px-6"
                   style={{ viewTransitionName: 'page-content' }}
                 >
                   {children}
-                </div>
-              ) : isAuthed === null ? (
-                <div className="px-4 pb-[var(--bottom-nav-h)] sm:px-6">
-                  <div className="h-screen" />
                 </div>
               ) : null}
             </div>

--- a/src/lib/api/serverBoardPrefetch.ts
+++ b/src/lib/api/serverBoardPrefetch.ts
@@ -38,7 +38,7 @@ async function fetchBoardPostsServer(
 
   const res = await fetch(url.toString(), {
     headers: { Authorization: `Bearer ${token}` },
-    cache: 'no-store',
+    next: { revalidate: 30 },
   });
 
   if (!res.ok) throw new Error('Failed to fetch posts');


### PR DESCRIPTION
## 📌 작업한 내용

Lighthouse LCP 4.8초 개선을 위한 3가지 수정                                                            
                                                                                                         
  1. AppFrame isAuthed 낙관적 초기화                                                                     

  isAuthed 초기값을 null → true로 변경하고 미도달 분기 제거

  - 기존: isAuthed === null인 동안 <div class="h-screen"/> (빈 화면) 렌더링
  - 변경: 즉시 콘텐츠 렌더링, 인증 실패 시에만 리다이렉트

  SSR로 게시글 데이터를 prefetch해도 isAuthed=null 때문에 서버가 빈 껍데기 HTML(5.6kB)만 내려주고 있었음.
   이 수정으로 SSR 콘텐츠가 초기 HTML에 포함됨.

  2. 게시글 목록 서버사이드 fetch 캐싱

  serverBoardPrefetch.ts의 게시글 fetch 옵션을 cache: 'no-store' → next: { revalidate: 30 }으로 변경

  - 최초 요청 이후 30초간 Next.js 서버 캐시에서 응답 → TTFB 단축

  3. background.webp 불필요한 preload 제거

  layout.tsx에서 background.webp preload 링크 제거

  - CSS background-image는 LCP 측정 대상이 아님
  - 불필요한 preload가 다른 중요 리소스와 대역폭 경쟁하던 문제 해결

## 🔍 참고 사항

  - LCP 병목 원인: isAuthed=null → 빈 화면 렌더링 → 클라이언트에서 ensureAccessToken() API 호출 완료
  후에야 콘텐츠 표시
  - 비인증 유저는 기존과 동일하게 로그인 페이지로 리다이렉트됨
  - 배포 후 로그인된 Chrome 세션에서 Lighthouse 재측정 필요

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
- [ ] (채팅) `/api/chatrooms` pagination에서 서버 cursor 재사용 원칙 준수 확인
