### PR TITLE
perf: SSR prefetch 적용 및 초기 로딩 속도 개선 (LCP 최적화)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,9 @@ const withBundleAnalyzer = bundleAnalyzer({
 const nextConfig: NextConfig = {
   devIndicators: false,
   output: 'standalone', // Docker 환경에서 경량 이미지 생성
+  experimental: {
+    inlineCss: true,
+  },
   images: {
     remotePatterns: [
       {

--- a/package.json
+++ b/package.json
@@ -72,10 +72,10 @@
     "vitest": "^4.0.17"
   },
   "browserslist": [
-    "chrome >= 92",
-    "firefox >= 90",
+    "chrome >= 93",
+    "firefox >= 92",
     "safari >= 15.4",
-    "edge >= 92",
+    "edge >= 93",
     "not dead"
   ],
   "pnpm": {

--- a/src/app/(app)/board/loading.tsx
+++ b/src/app/(app)/board/loading.tsx
@@ -2,8 +2,8 @@ export default function BoardLoading() {
   return (
     <main className="px-3 pt-4 pb-3">
       <div className="flex flex-col gap-3">
-        <div className="h-9 w-full rounded-lg bg-neutral-100 animate-pulse" />
-        <div className="h-8 w-24 rounded-full bg-neutral-100 animate-pulse" />
+        <div className="h-9 w-full animate-pulse rounded-lg bg-neutral-100" />
+        <div className="h-8 w-24 animate-pulse rounded-full bg-neutral-100" />
       </div>
       <div className="mt-4 space-y-3">
         {Array.from({ length: 5 }).map((_, i) => (

--- a/src/app/(app)/board/loading.tsx
+++ b/src/app/(app)/board/loading.tsx
@@ -1,0 +1,40 @@
+export default function BoardLoading() {
+  return (
+    <main className="px-3 pt-4 pb-3">
+      <div className="flex flex-col gap-3">
+        <div className="h-9 w-full rounded-lg bg-neutral-100 animate-pulse" />
+        <div className="h-8 w-24 rounded-full bg-neutral-100 animate-pulse" />
+      </div>
+      <div className="mt-4 space-y-3">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div
+            key={i}
+            className="animate-pulse rounded-2xl bg-white px-4 py-4 shadow-[0_8px_24px_rgba(15,23,42,0.06)]"
+          >
+            <div className="flex gap-3">
+              <div className="h-10 w-10 flex-shrink-0 rounded-full bg-neutral-200" />
+              <div className="min-w-0 flex-1 space-y-2">
+                <div className="flex items-center gap-2">
+                  <div className="h-3.5 w-20 rounded bg-neutral-200" />
+                  <div className="h-3 w-12 rounded bg-neutral-100" />
+                </div>
+                <div className="h-3 w-24 rounded bg-neutral-100" />
+                <div className="mt-2 h-4 w-3/4 rounded bg-neutral-200" />
+                <div className="h-3.5 w-full rounded bg-neutral-100" />
+                <div className="h-3.5 w-2/3 rounded bg-neutral-100" />
+                <div className="mt-1 flex gap-1.5">
+                  <div className="h-5 w-14 rounded-full bg-neutral-100" />
+                  <div className="h-5 w-16 rounded-full bg-neutral-100" />
+                </div>
+                <div className="mt-1 flex gap-3">
+                  <div className="h-3 w-10 rounded bg-neutral-100" />
+                  <div className="h-3 w-10 rounded bg-neutral-100" />
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/src/app/(app)/chat/page.tsx
+++ b/src/app/(app)/chat/page.tsx
@@ -1,5 +1,15 @@
+import { QueryClient, HydrationBoundary, dehydrate } from '@tanstack/react-query';
+
+import { prefetchChatRooms } from '@/lib/api/serverChatPrefetch';
 import ChatPlaceholderPage from '@/screens/chat/ChatPlaceholderPage';
 
-export default function Page() {
-  return <ChatPlaceholderPage />;
+export default async function Page() {
+  const queryClient = new QueryClient();
+  await prefetchChatRooms(queryClient);
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ChatPlaceholderPage />
+    </HydrationBoundary>
+  );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -589,7 +589,7 @@ html.accessibility-mode {
 
 @keyframes page-enter {
   from {
-    opacity: 0;
+    opacity: 0.3;
   }
   to {
     opacity: 1;
@@ -597,7 +597,7 @@ html.accessibility-mode {
 }
 
 .page-enter {
-  animation: page-enter 0.22s ease-out both;
+  animation: page-enter 0.1s ease-out both;
 }
 
 ::view-transition-old(root),

--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
 
 type Props = {
   isOpen: boolean;
@@ -35,7 +36,7 @@ export default function ConfirmModal({
 
   if (!isOpen) return null;
 
-  return (
+  return createPortal(
     <div
       className="fixed inset-0 z-[200] flex items-center justify-center"
       role="dialog"
@@ -73,6 +74,7 @@ export default function ConfirmModal({
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/src/components/layout/AppFrame.tsx
+++ b/src/components/layout/AppFrame.tsx
@@ -202,11 +202,7 @@ export default function AppFrame({
   }, [blockMessage, isNavigationBlocked]);
 
   const withViewTransition = (action: () => void) => {
-    if (typeof document !== 'undefined' && 'startViewTransition' in document) {
-      document.startViewTransition(action);
-    } else {
-      action();
-    }
+    action();
   };
 
   const requestNavigation = useCallback(

--- a/src/lib/api/serverBoardPrefetch.ts
+++ b/src/lib/api/serverBoardPrefetch.ts
@@ -10,22 +10,6 @@ import type { CursorPage } from '@/types/pagination';
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
-async function getServerAccessToken(cookieHeader: string): Promise<string | null> {
-  if (!BASE_URL) return null;
-  try {
-    const res = await fetch(new URL('/api/auth/tokens', BASE_URL).toString(), {
-      method: 'POST',
-      headers: { Cookie: cookieHeader },
-      cache: 'no-store',
-    });
-    if (!res.ok) return null;
-    const authHeader = res.headers.get('authorization');
-    return authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
-  } catch {
-    return null;
-  }
-}
-
 async function fetchBoardPostsServer(
   token: string,
   pageParam?: number,
@@ -190,14 +174,11 @@ async function fetchBoardCommentsServer(
 }
 
 export async function prefetchBoardDetail(queryClient: QueryClient, postId: number): Promise<void> {
-  const cookieStore = await cookies();
-  const cookieHeader = cookieStore
-    .getAll()
-    .map((c) => `${c.name}=${c.value}`)
-    .join('; ');
+  if (!BASE_URL) return;
 
-  const token = await getServerAccessToken(cookieHeader);
-  if (!token || !BASE_URL) return;
+  const cookieStore = await cookies();
+  const token = cookieStore.get('devths_at')?.value;
+  if (!token) return;
 
   await Promise.all([
     queryClient.prefetchQuery({
@@ -212,14 +193,11 @@ export async function prefetchBoardDetail(queryClient: QueryClient, postId: numb
 }
 
 export async function prefetchBoardPosts(queryClient: QueryClient): Promise<void> {
-  const cookieStore = await cookies();
-  const cookieHeader = cookieStore
-    .getAll()
-    .map((c) => `${c.name}=${c.value}`)
-    .join('; ');
+  if (!BASE_URL) return;
 
-  const token = await getServerAccessToken(cookieHeader);
-  if (!token || !BASE_URL) return;
+  const cookieStore = await cookies();
+  const token = cookieStore.get('devths_at')?.value;
+  if (!token) return;
 
   const params = { size: BOARD_PAGE_SIZE, sort: 'LATEST' as BoardSort, tags: [] as BoardTag[] };
 

--- a/src/lib/api/serverChatPrefetch.ts
+++ b/src/lib/api/serverChatPrefetch.ts
@@ -8,22 +8,6 @@ import type { ChatRoomListResponse } from '@/lib/api/chatRooms';
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
-async function getServerAccessToken(cookieHeader: string): Promise<string | null> {
-  if (!BASE_URL) return null;
-  try {
-    const res = await fetch(new URL('/api/auth/tokens', BASE_URL).toString(), {
-      method: 'POST',
-      headers: { Cookie: cookieHeader },
-      cache: 'no-store',
-    });
-    if (!res.ok) return null;
-    const authHeader = res.headers.get('authorization');
-    return authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
-  } catch {
-    return null;
-  }
-}
-
 async function fetchChatRoomsServer(token: string, size: number): Promise<ChatRoomListResponse> {
   const url = new URL('/api/chatrooms', BASE_URL);
   url.searchParams.set('type', 'PRIVATE');
@@ -43,14 +27,11 @@ async function fetchChatRoomsServer(token: string, size: number): Promise<ChatRo
 }
 
 export async function prefetchChatRooms(queryClient: QueryClient): Promise<void> {
-  const cookieStore = await cookies();
-  const cookieHeader = cookieStore
-    .getAll()
-    .map((c) => `${c.name}=${c.value}`)
-    .join('; ');
+  if (!BASE_URL) return;
 
-  const token = await getServerAccessToken(cookieHeader);
-  if (!token || !BASE_URL) return;
+  const cookieStore = await cookies();
+  const token = cookieStore.get('devths_at')?.value;
+  if (!token) return;
 
   await queryClient.prefetchInfiniteQuery({
     queryKey: chatKeys.rooms({ size: ROOM_PAGE_SIZE, cursor: null }),

--- a/src/lib/api/serverChatPrefetch.ts
+++ b/src/lib/api/serverChatPrefetch.ts
@@ -24,10 +24,7 @@ async function getServerAccessToken(cookieHeader: string): Promise<string | null
   }
 }
 
-async function fetchChatRoomsServer(
-  token: string,
-  size: number,
-): Promise<ChatRoomListResponse> {
+async function fetchChatRoomsServer(token: string, size: number): Promise<ChatRoomListResponse> {
   const url = new URL('/api/chatrooms', BASE_URL);
   url.searchParams.set('type', 'PRIVATE');
   url.searchParams.set('size', String(size));

--- a/src/lib/api/serverChatPrefetch.ts
+++ b/src/lib/api/serverChatPrefetch.ts
@@ -1,0 +1,66 @@
+import { QueryClient } from '@tanstack/react-query';
+import { cookies } from 'next/headers';
+
+import { ROOM_PAGE_SIZE } from '@/constants/chat';
+import { chatKeys } from '@/lib/hooks/chat/queryKeys';
+
+import type { ChatRoomListResponse } from '@/lib/api/chatRooms';
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+async function getServerAccessToken(cookieHeader: string): Promise<string | null> {
+  if (!BASE_URL) return null;
+  try {
+    const res = await fetch(new URL('/api/auth/tokens', BASE_URL).toString(), {
+      method: 'POST',
+      headers: { Cookie: cookieHeader },
+      cache: 'no-store',
+    });
+    if (!res.ok) return null;
+    const authHeader = res.headers.get('authorization');
+    return authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchChatRoomsServer(
+  token: string,
+  size: number,
+): Promise<ChatRoomListResponse> {
+  const url = new URL('/api/chatrooms', BASE_URL);
+  url.searchParams.set('type', 'PRIVATE');
+  url.searchParams.set('size', String(size));
+
+  const res = await fetch(url.toString(), {
+    headers: { Authorization: `Bearer ${token}` },
+    next: { revalidate: 30 },
+  });
+  if (!res.ok) throw new Error('Failed to fetch chat rooms');
+
+  const json = (await res.json()) as { data?: ChatRoomListResponse };
+  const data = json.data;
+  if (!data) throw new Error('Invalid response format');
+
+  return data;
+}
+
+export async function prefetchChatRooms(queryClient: QueryClient): Promise<void> {
+  const cookieStore = await cookies();
+  const cookieHeader = cookieStore
+    .getAll()
+    .map((c) => `${c.name}=${c.value}`)
+    .join('; ');
+
+  const token = await getServerAccessToken(cookieHeader);
+  if (!token || !BASE_URL) return;
+
+  await queryClient.prefetchInfiniteQuery({
+    queryKey: chatKeys.rooms({ size: ROOM_PAGE_SIZE, cursor: null }),
+    queryFn: () => fetchChatRoomsServer(token, ROOM_PAGE_SIZE),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage: ChatRoomListResponse) =>
+      lastPage.hasNext ? (lastPage.cursor ?? undefined) : undefined,
+    pages: 1,
+  });
+}

--- a/src/lib/auth/token.ts
+++ b/src/lib/auth/token.ts
@@ -1,4 +1,5 @@
 const ACCESS_TOKEN_KEY = 'devths_access_token';
+const ACCESS_TOKEN_COOKIE = 'devths_at';
 const TEMP_TOKEN_KEY = 'devths_signup_temp_token';
 const SIGNUP_EMAIL_KEY = 'devths_signup_email';
 const AUTH_REDIRECT_KEY = 'devths_auth_redirect';
@@ -6,6 +7,11 @@ const AUTH_REDIRECT_KEY = 'devths_auth_redirect';
 export function setAccessToken(token: string) {
   if (typeof window === 'undefined') return;
   localStorage.setItem(ACCESS_TOKEN_KEY, token);
+
+  const payload = parseJwtPayload(token);
+  const exp = payload?.exp;
+  const maxAge = typeof exp === 'number' ? Math.max(0, exp - Math.floor(Date.now() / 1000)) : 7200;
+  document.cookie = `${ACCESS_TOKEN_COOKIE}=${token}; Path=/; Secure; SameSite=Lax; Max-Age=${maxAge}`;
 }
 
 export function getAccessToken() {
@@ -84,6 +90,7 @@ export function getUserIdFromAccessToken(): number | null {
 export function clearAccessToken() {
   if (typeof window === 'undefined') return;
   localStorage.removeItem(ACCESS_TOKEN_KEY);
+  document.cookie = `${ACCESS_TOKEN_COOKIE}=; Path=/; Max-Age=0`;
 }
 
 export function setTempToken(token: string) {

--- a/src/screens/board/BoardListPage.tsx
+++ b/src/screens/board/BoardListPage.tsx
@@ -2,13 +2,13 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { Bell, Loader2, Plus, Search } from 'lucide-react';
+import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import BoardPostCard from '@/components/board/BoardPostCard';
 import BoardSortTabs from '@/components/board/BoardSortTabs';
 import BoardTagFilter from '@/components/board/BoardTagFilter';
-import BoardUserMiniProfile from '@/components/board/BoardUserMiniProfile';
 import { useHeader } from '@/components/layout/HeaderContext';
 import { useNavigationGuard } from '@/components/layout/NavigationGuardContext';
 import ListLoadMoreSentinel from '@/components/llm/rooms/ListLoadMoreSentinel';
@@ -28,6 +28,8 @@ import { useUnreadCountQuery } from '@/lib/hooks/notifications/useUnreadCountQue
 import { userKeys } from '@/lib/hooks/users/queryKeys';
 
 import type { BoardSort, BoardTag } from '@/types/board';
+
+const BoardUserMiniProfile = dynamic(() => import('@/components/board/BoardUserMiniProfile'));
 
 export default function BoardListPage() {
   const router = useRouter();

--- a/src/screens/board/BoardListPage.tsx
+++ b/src/screens/board/BoardListPage.tsx
@@ -426,7 +426,7 @@ export default function BoardListPage() {
                     post={post}
                     onClick={handlePostClick}
                     onAuthorClick={handleAuthorClick}
-                    priority={index === 0}
+                    priority={index < 3}
                   />
                 ))}
                 <div className="px-4 pt-2">

--- a/src/screens/chat/ChatPlaceholderPage.tsx
+++ b/src/screens/chat/ChatPlaceholderPage.tsx
@@ -259,7 +259,7 @@ export default function ChatPlaceholderPage() {
     <>
       <main className={isEmptyState ? '' : 'px-3 pt-4 pb-24'}>
         {isLoading ? (
-          <div className="mt-4 flex h-[40vh] items-center justify-center rounded-2xl border border-neutral-200 bg-white text-sm text-neutral-500">
+          <div className="mt-4 flex h-[40vh] items-center justify-center text-sm text-neutral-500">
             채팅방 목록을 불러오는 중입니다...
           </div>
         ) : null}


### PR DESCRIPTION
## 📌 작업한 내용

  LCP(Largest Contentful Paint) 개선 작업
                                                                               
  1. 불필요한 레거시 폴리필 제거 (browserslist 버전 상향)
  - Chrome 92→93, Firefox 90→92, Edge 92→93으로 상향하여 불필요한 레거시 JS
  번들 제거

  2. 페이지 전환 속도 개선
  - document.startViewTransition() 제거 → 직접 action() 호출로 변경
  - page-enter 애니메이션 opacity: 0→0.3 으로 조정 (opacity:0은 LCP 요소 측정
  자체를 차단함)

  3. 채팅 페이지 SSR 적용 및 게시판 이미지 우선 로딩
  - /chat 페이지에 HydrationBoundary + prefetchChatRooms SSR 적용
  - BoardListPage에서 상위 3개 게시글 이미지에 priority prop 추가 (fetchpriority="high")
  - BoardUserMiniProfile 컴포넌트 dynamic import로 변경하여 초기 번들 경량화

  4. 게시판 로딩 스켈레톤 스트리밍 SSR 적용
  - src/app/(app)/board/loading.tsx 신규 생성
  - Next.js App Router Streaming SSR로 데이터 로딩 중 스켈레톤 즉시 표시

  5. SSR prefetch 토큰 인식 개선 (핵심)
  - 문제: refreshToken 쿠키가 Path: /api/auth로 설정되어 있어 /board 요청 시 브라우저가 쿠키를 전송하지 않음 → SSR prefetch에서 토큰 취득 불가 → queries:[]로 HTML 렌더링
  - 해결: 로그인/토큰 갱신 시 access token을 devths_at 쿠키(Path=/; Secure; SameSite=Lax)로 동기화
    - setAccessToken()에서 JWT exp 기반 Max-Age로 localStorage와 동시에 쿠키 저장
    - clearAccessToken()에서 쿠키도 함께 삭제
    - serverBoardPrefetch.ts, serverChatPrefetch.ts에서 devths_at 쿠키를 직접 읽어 SSR 데이터 프리패치

  6. 채팅 목록 로딩 UI 개선
  - 로딩 중 불필요한 테두리/배경 제거

## 🔍 참고 사항

  - devths_at 쿠키는 localStorage와 동일한 보안 수준 (non-HttpOnly, 클라이언트 JS로 설정)
  - SSR prefetch 동작 확인 방법: 게시판 페이지에서 Cmd+Option+U → HTML 소스의 __NEXT_DATA__ 또는 queries 배열에 실제 게시글 데이터가 포함되는지 확인
  - Lighthouse는 로그인 세션을 유지하지 않으므로 Chrome DevTools Lighthouse 탭으로 측정 필요
  - inlineCss: true 옵션은 Next.js 15 experimental 기능으로, 렌더 블로킹 CSS를 제거함

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
- [ ] (채팅) `/api/chatrooms` pagination에서 서버 cursor 재사용 원칙 준수 확인
