### PR TITLE
fix: 인기순 최소 좋아요 기준 500 → 5로 변경

### DIFF
--- a/src/constants/board.ts
+++ b/src/constants/board.ts
@@ -15,7 +15,7 @@ export const BOARD_SORT_OPTIONS = [
   { key: 'FOLLOWING', label: '팔로잉' },
 ] as const satisfies readonly { key: BoardSort; label: string }[];
 
-export const POPULAR_MIN_LIKES = 500;
+export const POPULAR_MIN_LIKES = 5;
 
 export const BOARD_PAGE_SIZE = 10;
 export const FOLLOWINGS_FETCH_SIZE = 100;


### PR DESCRIPTION
## 📌 작업한 내용

인기순 정렬 기준 최소 좋아요 수를 500개에서 5개로 변경

## 🔍 참고 사항

`src/constants/board.ts`의 `POPULAR_MIN_LIKES` 상수 수정

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
- [ ] (채팅) `/api/chatrooms` pagination에서 서버 cursor 재사용 원칙 준수 확인
