### PR TITLE
fix: 토큰 만료 상태에서 로그아웃 시 발생하는 오류 수정

### DIFF
--- a/src/components/mypage/MyPageScreen.tsx
+++ b/src/components/mypage/MyPageScreen.tsx
@@ -96,7 +96,7 @@ export default function MyPageScreen() {
         toast('푸시 알림 해제에 실패했지만 로그아웃은 계속 진행합니다.');
       }
       const result = await postLogout();
-      if (!result.ok) {
+      if (!result.ok && result.status !== 401) {
         throw new Error('로그아웃에 실패했습니다.');
       }
       clearAccessToken();

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -31,6 +31,14 @@ Sentry.init({
   // Enable sending user PII (Personally Identifiable Information)
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
   sendDefaultPii: true,
+
+  beforeSend(event) {
+    // FCM 토큰 삭제(로그아웃 시)는 서버 500 응답이 예상되는 상황이므로 Sentry 전송 제외
+    if (event.request?.url?.includes('/api/notifications/tokens')) {
+      return null;
+    }
+    return event;
+  },
 });
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -1,4 +1,5 @@
 import { apiRequest } from '@/lib/api/client';
+import { getAccessToken } from '@/lib/auth/token';
 
 import type { ApiErrorResponse, ApiResponse } from '@/types/api';
 
@@ -76,10 +77,13 @@ export type PostLogoutResult = {
 };
 
 export async function postLogout(): Promise<PostLogoutResult> {
+  const token = getAccessToken();
   const { ok, status, json } = await apiRequest<null>({
     method: 'POST',
     path: '/api/auth/logout',
-    withAuth: true,
+    withAuth: false,
+    credentials: 'include',
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
   });
 
   return { ok, status, json };

--- a/src/lib/api/notifications.ts
+++ b/src/lib/api/notifications.ts
@@ -1,4 +1,5 @@
-import { api, type ApiClientResult } from '@/lib/api/client';
+import { api, apiRequest, type ApiClientResult } from '@/lib/api/client';
+import { getAccessToken } from '@/lib/auth/token';
 
 import type { NotificationListResponse, UnreadCountResponse } from '@/types/notifications';
 
@@ -40,7 +41,14 @@ export async function postFcmToken(
 }
 
 export async function deleteFcmToken(deviceId: string): Promise<ApiClientResult<unknown>> {
-  return api.delete(`/api/notifications/tokens/${encodeURIComponent(deviceId)}`);
+  const token = getAccessToken();
+  return apiRequest({
+    method: 'DELETE',
+    path: `/api/notifications/tokens/${encodeURIComponent(deviceId)}`,
+    withAuth: false,
+    credentials: 'include',
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
 }
 
 export async function patchFcmToken(


### PR DESCRIPTION
## 📌 작업한 내용

                                                                                 
  - 토큰 만료 상태에서 로그아웃 시 실패하던 문제 수정                            
    - `postLogout`, `deleteFcmToken`을 `withAuth: false`로 변경하여 만료된 토큰으로 인한 불필요한 갱신 요청(`POST /api/auth/tokens`) 제거                 
    - 토큰이 있을 경우 `Authorization` 헤더를 수동으로 주입, refresh token 쿠키 그대로 전송                                                                   
    - 로그아웃 API가 401을 반환하는 경우(이미 인증 해제 상태) 성공으로 처리하여 정상 로그아웃 흐름 진행                                                        
  - FCM 토큰 삭제 500 에러로 인한 Sentry 429 방지
    - `/api/notifications/tokens` 엔드포인트 에러는 로그아웃 시 예상되는 상황이므로 `beforeSend`에서 Sentry 전송 제외

## 🔍 참고 사항

  - FCM 토큰 삭제 API가 인증 없는 요청에 401 대신 500을 반환하는 것은 서버 사이드 이슈로, 클라이언트에서는 이미 실패 시 로그아웃을 계속 진행하도록 처리되어 있음
  - `postLogout` / `deleteFcmToken` 모두 `credentials: 'include'`를 유지하여 refresh token 쿠키는 계속 전송됨

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
- [ ] (채팅) `/api/chatrooms` pagination에서 서버 cursor 재사용 원칙 준수 확인
