### PR TITLE
fix: STOMP 토큰 만료 시 무한 재연결 및 401 에러 제거

### DIFF
--- a/src/components/layout/AppFrame.tsx
+++ b/src/components/layout/AppFrame.tsx
@@ -10,10 +10,17 @@ import Header from '@/components/layout/Header';
 import { HeaderContext, type HeaderOptions } from '@/components/layout/HeaderContext';
 import { NavigationGuardContext } from '@/components/layout/NavigationGuardContext';
 import LlmAnalysisTaskWatcher from '@/components/llm/analysis/LlmAnalysisTaskWatcher';
-import { ensureAccessToken } from '@/lib/api/client';
-import { clearAccessToken, getUserIdFromAccessToken, setAuthRedirect } from '@/lib/auth/token';
+import { ACCESS_TOKEN_REFRESHED_EVENT, ensureAccessToken } from '@/lib/api/client';
+import {
+  clearAccessToken,
+  getAccessToken,
+  getUserIdFromAccessToken,
+  isAccessTokenExpired,
+  setAuthRedirect,
+} from '@/lib/auth/token';
 import { applyRealtimeRoomNotification } from '@/lib/chat/realtimeRoomCache';
 import { clearRejoinedRoomUiOverride } from '@/lib/chat/rejoinedRoomUiCache';
+import { chatStompManager } from '@/lib/chat/stompManager';
 import { chatKeys } from '@/lib/hooks/chat/queryKeys';
 import { useChatRealtimeConnection } from '@/lib/hooks/chat/useChatRealtimeConnection';
 import { useChatSubscriptions } from '@/lib/hooks/chat/useChatSubscriptions';
@@ -82,7 +89,12 @@ export default function AppFrame({
   const defaultFrameOptions = useMemo<AppFrameOptions>(() => ({ showBottomNav: true }), []);
   const [frameOptions, setFrameOptions] = useState<AppFrameOptions>(defaultFrameOptions);
   const isBottomNavVisible = true;
-  const [isAuthed, setIsAuthed] = useState<boolean | null>(true);
+  const [isAuthed, setIsAuthed] = useState<boolean | null>(null);
+  const isAuthedRef = useRef<boolean | null>(null);
+
+  useEffect(() => {
+    isAuthedRef.current = isAuthed;
+  }, [isAuthed]);
   const [isNavigationBlocked, setIsNavigationBlocked] = useState(false);
   const [blockMessage, setBlockMessage] = useState('');
   const [blockedNavigationHandler, setBlockedNavigationHandler] = useState<
@@ -140,6 +152,24 @@ export default function AppFrame({
     onUserNotification: handleChatUserNotification,
   });
 
+  // 이벤트 기반 재연결: 토큰 갱신 성공 직후 STOMP가 끊겨 있으면 즉시 복구 (네비게이션 없이도 동작)
+  useEffect(() => {
+    const handleTokenRefreshed = () => {
+      const token = getAccessToken();
+      if (!token || isAccessTokenExpired(token)) return;
+
+      const stompStatus = chatStompManager.connectionStatus;
+      if (stompStatus === 'disconnected' || stompStatus === 'error') {
+        chatStompManager.connect();
+      }
+    };
+
+    window.addEventListener(ACCESS_TOKEN_REFRESHED_EVENT, handleTokenRefreshed);
+    return () => {
+      window.removeEventListener(ACCESS_TOKEN_REFRESHED_EVENT, handleTokenRefreshed);
+    };
+  }, []);
+
   useEffect(() => {
     setOptions(defaultOptions);
   }, [defaultOptions]);
@@ -151,6 +181,8 @@ export default function AppFrame({
     let isCancelled = false;
 
     const checkAuth = async () => {
+      if (isAuthedRef.current === false) return;
+
       const restored = await ensureAccessToken();
       if (isCancelled) {
         return;
@@ -158,6 +190,11 @@ export default function AppFrame({
 
       if (restored) {
         setIsAuthed(true);
+        // 네비게이션 시점 안전망: 이벤트 기반 복구가 안 된 경우를 대비
+        const stompStatus = chatStompManager.connectionStatus;
+        if (stompStatus === 'disconnected' || stompStatus === 'error') {
+          chatStompManager.connect();
+        }
         return;
       }
 

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -7,6 +7,9 @@ import {
 
 import type { ApiErrorResponse, ApiResponse } from '@/types/api';
 
+// 토큰 갱신 성공 시 발행하는 전역 이벤트 (STOMP 재연결 트리거 등에 활용)
+export const ACCESS_TOKEN_REFRESHED_EVENT = 'access-token-refreshed';
+
 const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
 let isRefreshing = false;
@@ -31,6 +34,9 @@ async function refreshAccessToken(): Promise<boolean> {
 
     if (newToken) {
       setAccessToken(newToken);
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent(ACCESS_TOKEN_REFRESHED_EVENT));
+      }
       return true;
     }
 

--- a/src/lib/chat/stompManager.ts
+++ b/src/lib/chat/stompManager.ts
@@ -3,8 +3,8 @@
 import { Client, type IMessage, type StompHeaders, type StompSubscription } from '@stomp/stompjs';
 import SockJS from 'sockjs-client';
 
-import { buildApiUrl, ensureAccessToken } from '@/lib/api/client';
-import { getAccessToken } from '@/lib/auth/token';
+import { buildApiUrl } from '@/lib/api/client';
+import { getAccessToken, isAccessTokenExpired } from '@/lib/auth/token';
 import { toast } from '@/lib/toast/store';
 
 export type ChatStompConnectionStatus =
@@ -150,14 +150,13 @@ class ChatStompManager {
         }
       },
       beforeConnect: async () => {
-        await ensureAccessToken();
         const token = getAccessToken();
 
-        if (!token) {
+        if (!token || isAccessTokenExpired(token)) {
           this.connectRequested = false;
-          this.logWarn('beforeConnect failed: access token not found, stop reconnecting');
+          this.logWarn('beforeConnect failed: access token missing or expired, stop reconnecting');
           this.notifyFailureOnce('auth-missing', '실시간 연결 인증에 실패했습니다.');
-          throw new Error('Missing access token for STOMP CONNECT');
+          throw new Error('Missing or expired access token for STOMP CONNECT');
         }
 
         client.connectHeaders = {

--- a/src/lib/chat/stompManager.ts
+++ b/src/lib/chat/stompManager.ts
@@ -154,7 +154,8 @@ class ChatStompManager {
         const token = getAccessToken();
 
         if (!token) {
-          this.logWarn('beforeConnect failed: access token not found');
+          this.connectRequested = false;
+          this.logWarn('beforeConnect failed: access token not found, stop reconnecting');
           this.notifyFailureOnce('auth-missing', '실시간 연결 인증에 실패했습니다.');
           throw new Error('Missing access token for STOMP CONNECT');
         }


### PR DESCRIPTION
## 📌 작업한 내용

  - STOMP 재연결 시 발생하던 불필요한 토큰 갱신 요청(`POST /api/auth/tokens`) 제거
    - `beforeConnect`에서 `ensureAccessToken()` 호출 제거
    - 대신 `isAccessTokenExpired()`로 클라이언트 측 토큰 유효성만 확인
    - 토큰이 없거나 만료된 경우 `connectRequested = false`로 설정해 무한 재연결 루프 차단
  - 토큰 갱신 성공 시 이벤트 기반 STOMP 재연결 구현
    - `refreshAccessToken()` 성공 시 `ACCESS_TOKEN_REFRESHED_EVENT` 전역 이벤트 발행
    - `AppFrame`에서 이벤트를 구독해 STOMP가 끊겨 있을 때 즉시 `connect()` 재호출
    - 네비게이션 없이도 토큰 갱신 직후 실시간 연결이 자동 복구됨
    - `checkAuth` 내 STOMP 재연결은 네비게이션 시점 안전망으로 유지
  - 인증 상태(`isAuthed`) 초기값을 `null`로 변경해 상태 의미 명확화
    - `null`: 확인 전 / `true`: 인증됨 / `false`: 인증 안 됨

## 🔍 참고 사항

  - 인증 책임(토큰 갱신)과 소켓 연결 책임을 분리한 구조로 개선
    - `stompManager`: 소켓 연결/재연결/구독 관리만 담당
    - `client.ts` / `AppFrame`: 토큰 갱신 및 재연결 트리거 담당                                              
  - 이벤트 이름은 `ACCESS_TOKEN_REFRESHED_EVENT` 상수로 관리 (오타 방지)                                     
  - `typeof window !== 'undefined'` 방어로 SSR 환경에서도 안전하게 동작                                      
  - STOMP `connect()` 내부에 `client.active || client.connected` early return이 있어 중복 연결 방지됨

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
- [ ] (채팅) `/api/chatrooms` pagination에서 서버 cursor 재사용 원칙 준수 확인
