### PR TITLE
fix: 로그아웃 직후 불필요한 토큰 갱신 시도 차단

### DIFF
--- a/src/components/layout/AppFrame.tsx
+++ b/src/components/layout/AppFrame.tsx
@@ -13,7 +13,9 @@ import LlmAnalysisTaskWatcher from '@/components/llm/analysis/LlmAnalysisTaskWat
 import { ACCESS_TOKEN_REFRESHED_EVENT, ensureAccessToken } from '@/lib/api/client';
 import {
   clearAccessToken,
+  clearLoggingOut,
   getAccessToken,
+  getIsLoggingOut,
   getUserIdFromAccessToken,
   isAccessTokenExpired,
   setAuthRedirect,
@@ -182,6 +184,11 @@ export default function AppFrame({
 
     const checkAuth = async () => {
       if (isAuthedRef.current === false) return;
+      if (getIsLoggingOut()) {
+        clearLoggingOut();
+        setIsAuthed(false);
+        return;
+      }
 
       const restored = await ensureAccessToken();
       if (isCancelled) {

--- a/src/components/mypage/MyPageScreen.tsx
+++ b/src/components/mypage/MyPageScreen.tsx
@@ -12,7 +12,7 @@ import { useHeader } from '@/components/layout/HeaderContext';
 import EditProfileModal from '@/components/mypage/EditProfileModal';
 import WithdrawModal from '@/components/mypage/WithdrawModal';
 import { postLogout } from '@/lib/api/auth';
-import { clearAccessToken } from '@/lib/auth/token';
+import { clearAccessToken, clearLoggingOut, markLoggingOut } from '@/lib/auth/token';
 import { useAccessibilityMode } from '@/lib/hooks/accessibility/useAccessibilityMode';
 import {
   unregisterFcmToken,
@@ -90,6 +90,7 @@ export default function MyPageScreen() {
     if (isLoggingOut) return;
 
     setIsLoggingOut(true);
+    markLoggingOut();
     try {
       const isFcmUnregistered = await unregisterFcmToken();
       if (!isFcmUnregistered) {
@@ -103,6 +104,7 @@ export default function MyPageScreen() {
       queryClient.clear();
       router.replace('/');
     } catch {
+      clearLoggingOut();
       toast('로그아웃에 실패했습니다.');
       setIsLoggingOut(false);
     }

--- a/src/lib/auth/token.ts
+++ b/src/lib/auth/token.ts
@@ -1,3 +1,17 @@
+let isLoggingOut = false;
+
+export function markLoggingOut() {
+  isLoggingOut = true;
+}
+
+export function clearLoggingOut() {
+  isLoggingOut = false;
+}
+
+export function getIsLoggingOut() {
+  return isLoggingOut;
+}
+
 const ACCESS_TOKEN_KEY = 'devths_access_token';
 const ACCESS_TOKEN_COOKIE = 'devths_at';
 const TEMP_TOKEN_KEY = 'devths_signup_temp_token';
@@ -6,6 +20,7 @@ const AUTH_REDIRECT_KEY = 'devths_auth_redirect';
 
 export function setAccessToken(token: string) {
   if (typeof window === 'undefined') return;
+  isLoggingOut = false;
   localStorage.setItem(ACCESS_TOKEN_KEY, token);
 
   const payload = parseJwtPayload(token);


### PR DESCRIPTION
## 📌 작업한 내용

  로그아웃 직후 AppFrame의 checkAuth가 pathname 변경으로 재실행되면서 불필요하게 POST /api/auth/tokens 를 시도하고 401 에러가 발생하는 문제를 수정했습니다.
                                                                                                             
  변경 파일       
  - src/lib/auth/token.ts — isLoggingOut 모듈 플래그 및 markLoggingOut / clearLoggingOut / getIsLoggingOut 함수 추가. setAccessToken() 호출 시 플래그 자동 해제                                                       
  - src/components/mypage/MyPageScreen.tsx — 로그아웃 시작 시 markLoggingOut() 호출, 실패 시 catch에서 clearLoggingOut() 호출                                                                                     
  - src/components/layout/AppFrame.tsx — checkAuth 진입 시 isLoggingOut 플래그를 확인하고 1회 소비 후 isAuthed(false) 처리 후 early return

## 🔍 참고 사항

  isLoggingOut은 영구 상태가 아닌 one-shot 플래그입니다.                                                     
   
  - checkAuth에서 읽는 순간 clearLoggingOut()으로 즉시 해제 → 이후 인증 체크는 정상 동작                     
  - 로그아웃 실패 시 catch에서 즉시 해제 → 이후 인증 복구 흐름이 막히지 않음
  - setAccessToken() 호출 시 자동 해제 → 재로그인 및 토큰 갱신 성공 시 별도 처리 불필요

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
- [ ] (채팅) `/api/chatrooms` pagination에서 서버 cursor 재사용 원칙 준수 확인
