### PR TITLE
fix: 채팅방 설정 개선 및 마이페이지 설정 페이지 추가

### DIFF
--- a/src/app/(app)/profile/settings/page.tsx
+++ b/src/app/(app)/profile/settings/page.tsx
@@ -1,0 +1,5 @@
+import ProfileSettingsScreen from '@/components/mypage/ProfileSettingsScreen';
+
+export default function ProfileSettingsPage() {
+  return <ProfileSettingsScreen />;
+}

--- a/src/components/layout/AppFrame.tsx
+++ b/src/components/layout/AppFrame.tsx
@@ -299,6 +299,8 @@ export default function AppFrame({
                 showBackButton={options.showBackButton}
                 onBackClick={options.onBackClick}
                 rightSlot={options.rightSlot}
+                showSettingsButton={options.showSettingsButton}
+                onSettingsClick={options.onSettingsClick}
                 showAccessibilityButton={options.showAccessibilityButton}
                 accessibilityActive={options.accessibilityActive}
                 onAccessibilityClick={options.onAccessibilityClick}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Bell, ChevronLeft, PersonStanding } from 'lucide-react';
+import { Bell, ChevronLeft, PersonStanding, Settings } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 
@@ -14,6 +14,8 @@ type HeaderProps = {
   showBackButton?: boolean;
   onBackClick?: () => void;
   rightSlot?: ReactNode;
+  showSettingsButton?: boolean;
+  onSettingsClick?: () => void;
   showAccessibilityButton?: boolean;
   accessibilityActive?: boolean;
   onAccessibilityClick?: () => void;
@@ -24,6 +26,8 @@ export default function Header({
   showBackButton = false,
   onBackClick,
   rightSlot,
+  showSettingsButton = false,
+  onSettingsClick,
   showAccessibilityButton = false,
   accessibilityActive = false,
   onAccessibilityClick,
@@ -46,6 +50,10 @@ export default function Header({
 
   const handleNotificationsClick = () => {
     requestNavigation(() => router.push('/notifications'));
+  };
+
+  const handleSettingsClick = () => {
+    onSettingsClick?.();
   };
 
   const handleAccessibilityButtonClick = () => {
@@ -112,6 +120,16 @@ export default function Header({
         <div className="ml-auto flex items-center justify-end gap-1">
           {rightSlot ?? (
             <>
+              {showSettingsButton ? (
+                <button
+                  type="button"
+                  onClick={handleSettingsClick}
+                  className="inline-flex h-11 w-11 items-center justify-center rounded-md hover:bg-neutral-100"
+                  aria-label="설정"
+                >
+                  <Settings aria-hidden="true" className="h-5 w-5" />
+                </button>
+              ) : null}
               {showAccessibilityButton ? (
                 <div ref={popoverRef} className="relative">
                   <button

--- a/src/components/layout/HeaderContext.tsx
+++ b/src/components/layout/HeaderContext.tsx
@@ -9,6 +9,8 @@ type HeaderOptions = {
   showBackButton?: boolean;
   onBackClick?: () => void;
   rightSlot?: ReactNode;
+  showSettingsButton?: boolean;
+  onSettingsClick?: () => void;
   showAccessibilityButton?: boolean;
   accessibilityActive?: boolean;
   onAccessibilityClick?: () => void;

--- a/src/components/mypage/MyPageScreen.tsx
+++ b/src/components/mypage/MyPageScreen.tsx
@@ -4,7 +4,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { Pencil } from 'lucide-react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import BoardPostCard from '@/components/board/BoardPostCard';
 import ConfirmModal from '@/components/common/ConfirmModal';
@@ -14,10 +14,7 @@ import WithdrawModal from '@/components/mypage/WithdrawModal';
 import { postLogout } from '@/lib/api/auth';
 import { clearAccessToken, clearLoggingOut, markLoggingOut } from '@/lib/auth/token';
 import { useAccessibilityMode } from '@/lib/hooks/accessibility/useAccessibilityMode';
-import {
-  unregisterFcmToken,
-  usePushNotificationToggle,
-} from '@/lib/hooks/notifications/useFcmToken';
+import { unregisterFcmToken } from '@/lib/hooks/notifications/useFcmToken';
 import { useMeQuery } from '@/lib/hooks/users/useMeQuery';
 import { useMyCommentsInfiniteQuery } from '@/lib/hooks/users/useMyCommentsInfiniteQuery';
 import { useMyPostsInfiniteQuery } from '@/lib/hooks/users/useMyPostsInfiniteQuery';
@@ -54,22 +51,22 @@ export default function MyPageScreen() {
   const [isWithdrawOpen, setIsWithdrawOpen] = useState(false);
   const [isLogoutConfirmOpen, setIsLogoutConfirmOpen] = useState(false);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
-  const {
-    isActive: isPushActive,
-    isPending: isPushPending,
-    toggle: togglePush,
-    isSupported: isPushSupported,
-  } = usePushNotificationToggle();
+
+  const handleOpenSettings = useCallback(() => {
+    router.push('/profile/settings');
+  }, [router]);
 
   useEffect(() => {
     setOptions({
+      showSettingsButton: true,
+      onSettingsClick: handleOpenSettings,
       showAccessibilityButton: true,
       accessibilityActive: isAccessibilityOn,
       onAccessibilityClick: toggleAccessibility,
     });
 
     return () => resetOptions();
-  }, [isAccessibilityOn, resetOptions, setOptions, toggleAccessibility]);
+  }, [handleOpenSettings, isAccessibilityOn, resetOptions, setOptions, toggleAccessibility]);
 
   const handleWithdraw = () => {
     setIsEditOpen(false);
@@ -302,27 +299,6 @@ export default function MyPageScreen() {
                 </p>
               </button>
             </div>
-
-            {isPushSupported && (
-              <div className="flex items-center justify-between rounded-xl border border-neutral-200 bg-white px-4 py-3">
-                <div>
-                  <p className="text-sm font-semibold text-neutral-900">푸시 알림</p>
-                  <p className="text-xs text-neutral-500">새 알림을 푸시로 받습니다</p>
-                </div>
-                <button
-                  type="button"
-                  role="switch"
-                  aria-checked={isPushActive}
-                  onClick={() => void togglePush()}
-                  disabled={isPushPending}
-                  className={`relative h-6 w-11 rounded-full transition-colors disabled:opacity-50 ${isPushActive ? 'bg-[#05C075]' : 'bg-neutral-300'}`}
-                >
-                  <span
-                    className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform ${isPushActive ? 'translate-x-5' : 'translate-x-0'}`}
-                  />
-                </button>
-              </div>
-            )}
           </div>
         )}
       </section>

--- a/src/components/mypage/ProfileSettingsScreen.tsx
+++ b/src/components/mypage/ProfileSettingsScreen.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect } from 'react';
+
+import { useHeader } from '@/components/layout/HeaderContext';
+import { useAccessibilityMode } from '@/lib/hooks/accessibility/useAccessibilityMode';
+import { usePushNotificationToggle } from '@/lib/hooks/notifications/useFcmToken';
+
+function ToggleSwitch({
+  checked,
+  disabled = false,
+  onClick,
+}: Readonly<{
+  checked: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+}>) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      onClick={onClick}
+      disabled={disabled}
+      className={`relative h-6 w-11 rounded-full transition-colors disabled:opacity-50 ${
+        checked ? 'bg-[#05C075]' : 'bg-neutral-300'
+      }`}
+    >
+      <span
+        className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform ${
+          checked ? 'translate-x-5' : 'translate-x-0'
+        }`}
+      />
+    </button>
+  );
+}
+
+export default function ProfileSettingsScreen() {
+  const router = useRouter();
+  const { setOptions, resetOptions } = useHeader();
+  const { isOn: isAccessibilityOn, toggle: toggleAccessibility } = useAccessibilityMode();
+  const {
+    isActive: isPushActive,
+    isPending: isPushPending,
+    toggle: togglePush,
+    isSupported: isPushSupported,
+  } = usePushNotificationToggle();
+
+  const handleBackClick = useCallback(() => {
+    router.push('/profile');
+  }, [router]);
+
+  useEffect(() => {
+    setOptions({
+      title: '설정',
+      showBackButton: true,
+      onBackClick: handleBackClick,
+    });
+
+    return () => resetOptions();
+  }, [handleBackClick, resetOptions, setOptions]);
+
+  return (
+    <main className="px-4 pt-4 pb-6">
+      <section className="rounded-2xl border border-neutral-200 bg-white">
+        {isPushSupported ? (
+          <div className="flex items-center justify-between gap-4 px-4 py-4">
+            <div>
+              <p className="text-sm font-semibold text-neutral-900">푸시 알림</p>
+              <p className="mt-1 text-xs text-neutral-500">새 알림을 푸시로 받습니다</p>
+            </div>
+            <ToggleSwitch
+              checked={isPushActive}
+              disabled={isPushPending}
+              onClick={() => {
+                void togglePush();
+              }}
+            />
+          </div>
+        ) : (
+          <div className="px-4 py-4">
+            <p className="text-sm font-semibold text-neutral-900">푸시 알림</p>
+            <p className="mt-1 text-xs text-neutral-500">
+              현재 기기에서는 푸시 알림 설정을 지원하지 않습니다.
+            </p>
+          </div>
+        )}
+
+        <div className="border-t border-neutral-200" />
+
+        <div className="flex items-center justify-between gap-4 px-4 py-4">
+          <div>
+            <p className="text-sm font-semibold text-neutral-900">접근성 모드</p>
+            <p className="mt-1 text-xs text-neutral-500">가독성을 높이는 스타일을 적용합니다</p>
+          </div>
+          <ToggleSwitch checked={isAccessibilityOn} onClick={toggleAccessibility} />
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/lib/api/serverChatPrefetch.ts
+++ b/src/lib/api/serverChatPrefetch.ts
@@ -15,7 +15,7 @@ async function fetchChatRoomsServer(token: string, size: number): Promise<ChatRo
 
   const res = await fetch(url.toString(), {
     headers: { Authorization: `Bearer ${token}` },
-    next: { revalidate: 30 },
+    cache: 'no-store',
   });
   if (!res.ok) throw new Error('Failed to fetch chat rooms');
 

--- a/src/screens/chat/ChatRoomPage.tsx
+++ b/src/screens/chat/ChatRoomPage.tsx
@@ -1109,61 +1109,6 @@ export default function ChatRoomPage({ roomId, mode = 'room' }: ChatRoomPageProp
                       />
                     </div>
                   </section>
-
-                  <section className="py-4">
-                    <p className="text-sm font-semibold text-neutral-900">
-                      최근 사진/파일 미리보기
-                    </p>
-                    <p className="mt-1 text-xs text-neutral-500">최근 공유된 이미지 최대 4장</p>
-
-                    {data?.recentImages?.length ? (
-                      <ul className="mt-3 grid grid-cols-2 gap-2">
-                        {data.recentImages.map((recentImage) => {
-                          const imageSrc = resolveChatAssetUrl(recentImage.s3Key);
-
-                          if (!imageSrc) {
-                            return (
-                              <li
-                                key={recentImage.attachmentId}
-                                className="flex aspect-square items-center justify-center rounded-lg border border-neutral-200 bg-neutral-50 px-1 text-center text-[10px] leading-4 text-neutral-400"
-                              >
-                                미리보기 불가
-                              </li>
-                            );
-                          }
-
-                          return (
-                            <li key={recentImage.attachmentId}>
-                              <button
-                                type="button"
-                                onClick={() =>
-                                  setImagePreview({
-                                    src: imageSrc,
-                                    alt: recentImage.originalName || '최근 이미지 미리보기',
-                                  })
-                                }
-                                className="block w-full overflow-hidden rounded-lg border border-neutral-200"
-                                aria-label={`${recentImage.originalName || '최근 이미지'} 확대 보기`}
-                              >
-                                <Image
-                                  src={imageSrc}
-                                  alt={recentImage.originalName || '최근 이미지'}
-                                  width={120}
-                                  height={120}
-                                  className="aspect-square h-auto w-full object-cover"
-                                  unoptimized
-                                />
-                              </button>
-                            </li>
-                          );
-                        })}
-                      </ul>
-                    ) : (
-                      <p className="mt-3 px-1 py-2 text-xs text-neutral-500">
-                        아직 공유된 이미지가 없습니다.
-                      </p>
-                    )}
-                  </section>
                 </div>
               </div>
 

--- a/src/screens/chat/ChatRoomPage.tsx
+++ b/src/screens/chat/ChatRoomPage.tsx
@@ -1068,10 +1068,10 @@ export default function ChatRoomPage({ roomId, mode = 'room' }: ChatRoomPageProp
       ) : null}
 
       {isSettingsPage ? (
-        <div className="fixed inset-x-0 top-14 bottom-0 z-40 overflow-y-auto">
-          <section className="mx-auto min-h-full w-full max-w-[430px] bg-white">
-            <div className="mx-auto flex min-h-full w-full max-w-[392px] flex-col px-5 pt-4 pb-6">
-              <div>
+        <div className="fixed inset-x-0 top-14 bottom-0 z-40 overflow-hidden bg-white">
+          <section className="mx-auto flex h-full w-full max-w-[430px] flex-col bg-white">
+            <div className="flex-1 overflow-y-auto">
+              <div className="mx-auto w-full max-w-[392px] px-5 pt-4 pb-6">
                 <div className="divide-y divide-neutral-200">
                   <section className="py-4">
                     <div className="flex items-center justify-between">
@@ -1111,8 +1111,10 @@ export default function ChatRoomPage({ roomId, mode = 'room' }: ChatRoomPageProp
                   </section>
                 </div>
               </div>
+            </div>
 
-              <div className="mt-auto pt-5">
+            <div className="shrink-0 border-t border-neutral-200 bg-white px-5 pt-4 pb-[calc(env(safe-area-inset-bottom)+1rem)] shadow-[0_-6px_16px_rgba(15,23,42,0.04)]">
+              <div className="mx-auto w-full max-w-[392px]">
                 <div className="grid grid-cols-2 gap-2">
                   <button
                     type="button"


### PR DESCRIPTION
## 📌 작업한 내용

  - 채팅방 설정 화면에서 `최근 사진/파일 미리보기` 섹션을 제거했습니다.
  - 채팅방 설정의 `채팅방 나가기` / `저장` 버튼이 항상 화면 하단에 고정되도록 레이아웃을 수정했습니다.
  - 채팅방 나가기 후 `/chat` 목록에 다시 진입했을 때, 방금 나간 채팅방이 다시 보이지 않도록 채팅 목록 서버 프리패치 캐시를 `no-store`로 변경했습니다.
  - 마이페이지 헤더에 설정 버튼을 추가하고, 설정 버튼 클릭 시 진입하는 전용 설정 페이지(`/profile/settings`)를 추가했습니다.
  - 마이페이지 설정 페이지에 기존 로직을 재사용한 `푸시 알림 토글`과 `접근성 모드 토글`을 배치했습니다.
  - 마이페이지 본문에 있던 푸시 알림 토글은 설정 페이지로 이동시키고, 마이페이지는 설정 진입 역할만 하도록 정리했습니다.

## 🔍 참고 사항

  - 푸시 알림 토글과 접근성 모드 토글은 기존 훅/로직을 그대로 사용하고, UI 위치만 설정 페이지로 이동했습니다.
  - 채팅 목록 재노출 문제는 서버 프리패치 캐시 설정 때문에 발생하던 현상이라, 목록 API 응답 자체가 아니라 서버 fetch 캐시 정책을 수정했습니다.
  - 변경 범위는 주로 채팅방 설정 UI, 마이페이지 헤더/설정 화면, 채팅 목록 서버 프리패치입니다.

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
- [ ] (채팅) `/api/chatrooms` pagination에서 서버 cursor 재사용 원칙 준수 확인
