### PR TITLE
fix: 스크롤바 유무에 따른 레이아웃 밀림 현상 수정

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -119,6 +119,10 @@
   * {
     @apply border-border outline-ring/50;
   }
+  html {
+    scrollbar-gutter: stable;
+  }
+
   body {
     @apply text-foreground;
     background-color: transparent;


### PR DESCRIPTION
## 📌 작업한 내용

  스크롤바 유무에 따라 콘텐츠 영역 너비가 변동되어 페이지 전환 시 화면이 좌우로 밀리는 현상 수정

  - `html { scrollbar-gutter: stable }` 적용으로 스크롤바 공간을 항상 예약하여 레이아웃 밀림 제거

## 🔍 참고 사항

  - Windows 환경처럼 스크롤바가 공간을 차지하는 OS에서 주로 발생하는 문제
  - macOS 기본 설정(오버레이 스크롤바)에서는 재현되지 않아 놓치기 쉬움

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
- [ ] (채팅) `/api/chatrooms` pagination에서 서버 cursor 재사용 원칙 준수 확인
