### PR TITLE
fix: 로그아웃 후 재로그인·신규 가입 시 FCM 토큰 등록 수정

### DIFF
--- a/src/lib/hooks/notifications/useFcmToken.ts
+++ b/src/lib/hooks/notifications/useFcmToken.ts
@@ -25,12 +25,18 @@ export async function unregisterFcmToken(): Promise<boolean> {
   const deviceId = getStoredDeviceId();
   if (!deviceId) return true;
 
+  let success = false;
   try {
     const result = await deleteFcmToken(deviceId);
-    return result.ok || result.status === 404;
+    success = result.ok || result.status === 404;
   } catch {
-    return false;
+    success = false;
+  } finally {
+    // 로그아웃 후 다른 계정(신규 포함)이 같은 디바이스에서 로그인할 때
+    // 동일 deviceId로 POST 충돌(500)이 발생하지 않도록 항상 제거
+    localStorage.removeItem(DEVICE_ID_KEY);
   }
+  return success;
 }
 
 export function useFcmToken() {

--- a/src/lib/hooks/notifications/useFcmToken.ts
+++ b/src/lib/hooks/notifications/useFcmToken.ts
@@ -52,6 +52,20 @@ export function useFcmToken() {
       }
 
       const deviceId = getOrCreateDeviceId();
+
+      // 재로그인 시 기존 레코드가 남아 있을 수 있으므로 PATCH로 재활성화 먼저 시도
+      const patchResult = await patchFcmToken(deviceId, { isActive: true });
+      if (patchResult.ok) {
+        localStorage.setItem(PUSH_ACTIVE_KEY, 'true');
+        return;
+      }
+
+      // 레코드 없음(404) → 신규 등록
+      if (patchResult.status !== 404) {
+        toast('푸시 알림 등록에 실패했어요. 잠시 후 다시 시도해 주세요.');
+        return;
+      }
+
       const postResult = await postFcmToken(deviceId, { token, deviceType: 'WEB' });
       if (!postResult.ok) {
         toast('푸시 알림 등록에 실패했어요. 잠시 후 다시 시도해 주세요.');


### PR DESCRIPTION
## 📌 작업한 내용

  로그아웃 후 재로그인하거나 같은 브라우저에서 신규 가입 시
  `POST /api/notifications/tokens/{deviceId}` 가 500을 반환하는 문제를 수정했습니다.

  **원인**
  - `useFcmToken`이 항상 POST만 시도하여, 백엔드에 동일 `deviceId` 레코드가
    남아 있을 경우 중복 키 오류(500) 발생
  - 로그아웃 시 `fcm_device_id`가 localStorage에 유지되어, 다른 계정 또는
    신규 가입 유저가 같은 브라우저에서 로그인하면 동일 UUID로 POST 충돌 발생

  **수정 내용**
  - `useFcmToken`: POST 전 PATCH로 기존 레코드 재활성화를 먼저 시도하고,
    404(레코드 없음)일 때만 POST로 신규 등록
  - `unregisterFcmToken`: DELETE 성공 여부와 무관하게 로그아웃 시
    `fcm_device_id`를 localStorage에서 제거하여 다음 로그인 시 충돌 방지

## 🔍 참고 사항

  - 변경 파일: `src/lib/hooks/notifications/useFcmToken.ts`
  - `Refused to get unsafe header "Set-Cookie"` 콘솔 경고는 axios가 XHR 응답 헤더를
    열거할 때 브라우저가 차단하는 정상 보안 동작으로, 별도 수정 불필요

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
- [ ] (채팅) `/api/chatrooms` pagination에서 서버 cursor 재사용 원칙 준수 확인
