### PR TITLE
fix: useFcmToken 자동 등록 실패 시 토스트 제거

### DIFF
--- a/src/lib/hooks/notifications/useFcmToken.ts
+++ b/src/lib/hooks/notifications/useFcmToken.ts
@@ -52,10 +52,7 @@ export function useFcmToken() {
       if (permission !== 'granted') return;
 
       const token = await requestFcmToken();
-      if (!token) {
-        toast('푸시 알림 등록에 실패했어요. 잠시 후 다시 시도해 주세요.');
-        return;
-      }
+      if (!token) return;
 
       const deviceId = getOrCreateDeviceId();
 
@@ -67,21 +64,15 @@ export function useFcmToken() {
       }
 
       // 레코드 없음(404) → 신규 등록
-      if (patchResult.status !== 404) {
-        toast('푸시 알림 등록에 실패했어요. 잠시 후 다시 시도해 주세요.');
-        return;
-      }
+      if (patchResult.status !== 404) return;
 
       const postResult = await postFcmToken(deviceId, { token, deviceType: 'WEB' });
-      if (!postResult.ok) {
-        toast('푸시 알림 등록에 실패했어요. 잠시 후 다시 시도해 주세요.');
-        return;
-      }
+      if (!postResult.ok) return;
       localStorage.setItem(PUSH_ACTIVE_KEY, 'true');
     };
 
     void register().catch(() => {
-      toast('푸시 알림 등록에 실패했어요. 잠시 후 다시 시도해 주세요.');
+      /* 자동 등록 실패는 사용자에게 노출하지 않음 */
     });
   }, []);
 }


### PR DESCRIPTION
## 📌 작업한 내용

  로그인 시 자동으로 실행되는 FCM 푸시 알림 등록(`useFcmToken`)이 실패할 때
  "푸시 알림 등록에 실패했어요" 토스트가 노출되는 문제를 수정했습니다.

  `useFcmToken`은 사용자가 직접 요청한 동작이 아닌 백그라운드 자동 등록이므로,
  실패 시 조용히 처리(silent fail)하도록 변경했습니다.
  사용자가 직접 토글하는 `usePushNotificationToggle`의 토스트는 그대로 유지됩니다.

## 🔍 참고 사항

<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
- [ ] (채팅) `/api/chatrooms` pagination에서 서버 cursor 재사용 원칙 준수 확인
