### PR TITLE
fix: PDF 마스킹 관련 빌드 의존성 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "typecheck": "tsc --noEmit",
     "check": "pnpm lint && pnpm format:check && pnpm typecheck",
     "test:run": "vitest run",
-    "postinstall": "cp node_modules/pdfjs-dist/build/pdf.worker.min.mjs public/pdf.worker.min.mjs"
+    "postinstall": "mkdir -p public && cp node_modules/pdfjs-dist/build/pdf.worker.min.mjs public/pdf.worker.min.mjs"
   },
   "dependencies": {
     "@fullcalendar/core": "^6.1.20",


### PR DESCRIPTION
## 📌 작업한 내용  
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- PDF 마스킹 기능 빌드 시 발생하던 의존성에서 폴더를 미리생성하는 방식으로 수정했습니다.  

## 🔍 참고 사항  

## 🖼️ 스크린샷  

## 🔗 관련 이슈  

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인