### PR TITLE
fix: 게시글 수정 페이지에서 PDF 재마스킹 시 빈 파일 로드 오류 수정

### DIFF
--- a/src/components/board/BoardPdfMaskModal.tsx
+++ b/src/components/board/BoardPdfMaskModal.tsx
@@ -230,7 +230,16 @@ export default function BoardPdfMaskModal({
   const handleComplete = useCallback(async () => {
     const { PDFDocument, rgb } = await import('pdf-lib');
 
-    const arrayBuffer = await attachment.file.arrayBuffer();
+    let arrayBuffer: ArrayBuffer;
+    if (attachment.previewUrl && !attachment.previewUrl.startsWith('blob:')) {
+      const res = await fetch(`/api/image-proxy?url=${encodeURIComponent(attachment.previewUrl)}`);
+      arrayBuffer = await res.arrayBuffer();
+    } else if (attachment.previewUrl) {
+      const res = await fetch(attachment.previewUrl);
+      arrayBuffer = await res.arrayBuffer();
+    } else {
+      arrayBuffer = await attachment.file.arrayBuffer();
+    }
     const pdfDoc = await PDFDocument.load(arrayBuffer);
     const pages = pdfDoc.getPages();
 


### PR DESCRIPTION
## 📌 작업한 내용

  ### 버그 수정                                             
  - **게시글 수정 페이지 PDF 재마스킹 오류 수정**: 이미 업로드된 PDF를 다시 마스킹하려 할 때 "No PDF header found" 오류 발생하는 문제 해결                                                        
    - 수정 페이지에서 기존 첨부파일은 빈 `File` 객체로 초기화되는데, `handleComplete`에서 `attachment.file.arrayBuffer()`를 읽어 빈 데이터를 PDF로 파싱하려다 실패                                                  
    - `attachment.previewUrl`이 있는 경우 해당 URL에서 실제 PDF 내용을 fetch하도록 수정

## 🔍 참고 사항

  - 수정 페이지(`BoardEditPage`)에서 서버 기존 첨부파일은 `new File([], fileName)` 빈 파일로 초기화되며, 실제 콘텐츠는 `previewUrl`(S3 URL)에 있음                                      
  - remote URL은 `/api/image-proxy`를 통해 fetch, blob URL은 직접 fetch, 파일 객체만 있는 경우 `arrayBuffer()` 사용 — 세 케이스 모두 처리

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
- [ ] (채팅) `/api/chatrooms` pagination에서 서버 cursor 재사용 원칙 준수 확인
