### PR TITLE
fix: lint에서 README.md 제외

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ node_modules
 dist
 build
 pnpm-lock.yaml
+README.md

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,6 +20,7 @@ const eslintConfig = defineConfig([
     'coverage/**',
 
     'public/pdf.worker.min.mjs',
+    'README.md',
   ]),
 
   prettier,


### PR DESCRIPTION
## 📌 작업한 내용
lint조건에서 Readmd.md를 제외합니다.

## 🔍 참고 사항

## 🖼️ 스크린샷

## 🔗 관련 이슈

## ✅ 체크리스트
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
- [ ] (채팅) `/api/chatrooms` pagination에서 서버 cursor 재사용 원칙 준수 확인
