### PR TITLE
온프레미스 배포 구성: pnpm 버전 고정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM node:22-alpine AS builder
 WORKDIR /app
 
 # pnpm 설치 및 의존성 복사
-RUN npm install -g pnpm
+RUN npm install -g pnpm@9
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 


### PR DESCRIPTION
pnpm 10+부터 ERR_PNPM_IGNORED_BUILDS 정책이 package.json의 pnpm.onlyBuiltDependencies를 더 이상 자동 존중하지 않아 빌드 실패 — pnpm@9로 고정해 해결.

## 📌 작업한 내용

<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->

## 🔍 참고 사항

<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
- [ ] (채팅) `/api/chatrooms` pagination에서 서버 cursor 재사용 원칙 준수 확인
